### PR TITLE
Add sentry 

### DIFF
--- a/transactions-api/Program.cs
+++ b/transactions-api/Program.cs
@@ -19,6 +19,7 @@ namespace transactions_api
 
         public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
+                .UseSentry(Environment.GetEnvironmentVariable("SENTRY_URL"))
                 .UseStartup<Startup>();
     }
 }

--- a/transactions-api/transactions-api.csproj
+++ b/transactions-api/transactions-api.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Sentry.AspNetCore" Version="1.1.2" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Logging exceptions via sentry has been added to the project. I've set it up via .netcore sdk instead of the raven-csharp way used in the tenancy-api as the configuration it way more simple and the exception logs contain breadcrumbs.