### PR TITLE
Replaced prop ref with tag ref 

### DIFF
--- a/transactions-api.Tests/V1/Controllers/TransactionsControllerTests.cs
+++ b/transactions-api.Tests/V1/Controllers/TransactionsControllerTests.cs
@@ -51,7 +51,7 @@ namespace UnitTests.V1.Controllers
             {
                 { "request", new Dictionary<string, object>
                     {
-                        {"propertyRef", request.PropertyRef}
+                        {"tagRef", request.TagRef}
                     }
                 },
                 { "generatedAt", datetime},
@@ -76,7 +76,7 @@ namespace UnitTests.V1.Controllers
             var faker = new Faker();
             var listTransactionsRequest = new ListTransactionsRequest
             {
-                PropertyRef = faker.Random.Hash()
+                TagRef = faker.Random.Hash()
             };
             return listTransactionsRequest;
         }
@@ -97,7 +97,7 @@ namespace UnitTests.V1.Controllers
             };
             var request = new ListTransactionsRequest
             {
-                PropertyRef = "testString"
+                TagRef = "testString"
             };
 
             var generatedAt = new DateTime(2019, 02, 22, 09, 52, 23, 23);
@@ -117,7 +117,7 @@ namespace UnitTests.V1.Controllers
             string json =
 @"{
   ""request"": {
-    ""propertyRef"": ""testString""
+    ""tagRef"": ""testString""
   },
   ""generatedAt"": ""2019-02-22T09:52:23.023Z"",
   ""transactions"": [

--- a/transactions-api.Tests/V1/Gateways/TransactionsGatewayTests.cs
+++ b/transactions-api.Tests/V1/Gateways/TransactionsGatewayTests.cs
@@ -28,8 +28,7 @@ namespace UnitTests.V1.Gateways
         [Test]
         public void GetTransactionsByPropertyRef_ReturnsEmptyArray()
         {
-            var responce = _classUnderTest.GetTransactionsByPropertyRef("random");
-
+            var responce = _classUnderTest.GetTransactionsByTagRef("random");
             Assert.AreEqual(0, responce.Count);
             Assert.AreEqual(null, responce.FirstOrDefault());
         }
@@ -55,7 +54,7 @@ namespace UnitTests.V1.Gateways
             _uhContext.RecType.Add(recType);
             _uhContext.SaveChanges();
 
-            var response = _classUnderTest.GetTransactionsByPropertyRef(dbTrans.PropRef).FirstOrDefault();
+            var response = _classUnderTest.GetTransactionsByTagRef(dbTrans.TagRef).FirstOrDefault();
 
             Assert.AreEqual(transaction.Amount, response.Amount);
             Assert.AreEqual(transaction.Code, response.Code);

--- a/transactions-api.Tests/V1/Helper/UhTransactionHelper.cs
+++ b/transactions-api.Tests/V1/Helper/UhTransactionHelper.cs
@@ -16,6 +16,7 @@ namespace UnitTests.V1.Helper
             UhTransaction uhTransaction = CopyTransactionFields(transaction);
             uhTransaction.Id = _faker.Random.Int();
             uhTransaction.PropRef = _faker.Random.AlphaNumeric(length: 12);
+            uhTransaction.TagRef = _faker.Random.AlphaNumeric(length: 9);
             uhTransaction.transno = _faker.Random.Int();
             uhTransaction.line_no = _faker.Random.Int();
             uhTransaction.adjustment = _faker.Random.Bool();
@@ -23,6 +24,7 @@ namespace UnitTests.V1.Helper
             uhTransaction.prop_deb = _faker.Random.Bool();
             uhTransaction.none_rent = _faker.Random.Bool();
             uhTransaction.receipted = _faker.Random.Bool();
+            uhTransaction.vat = _faker.Random.Bool();
           
             return uhTransaction;
         }

--- a/transactions-api.Tests/V1/Infrastructure/UhTransactionTests.cs
+++ b/transactions-api.Tests/V1/Infrastructure/UhTransactionTests.cs
@@ -17,6 +17,7 @@ namespace UnitTests.V1.Infrastructure
             UhTransaction b = new UhTransaction
             {
                 PropRef = a.PropRef,
+                TagRef = a.TagRef,
                 Amount = a.Amount,
                 Code = a.Code,
                 Date = a.Date,

--- a/transactions-api.Tests/V1/UseCase/ListTransactionsUsecaseTests.cs
+++ b/transactions-api.Tests/V1/UseCase/ListTransactionsUsecaseTests.cs
@@ -36,12 +36,12 @@ namespace UnitTests.V1.UseCase
         [Test]
         public void CanGetListOfTransactionsByPropertyReference()
         {
-            var propertyRef = _faker.Random.Hash();
-            var request = new ListTransactionsRequest {PropertyRef = propertyRef};
+            var tagRef = _faker.Random.Hash();
+            var request = new ListTransactionsRequest {TagRef = tagRef};
 
             List<Transaction> response = new List<Transaction> {new Transaction()};
 
-            _transactionsGateway.Setup(foo => foo.GetTransactionsByPropertyRef(propertyRef)).Returns(response);
+            _transactionsGateway.Setup(foo => foo.GetTransactionsByTagRef(tagRef)).Returns(response);
 
             var results = _classUnderTest.Execute(request);
 
@@ -50,31 +50,31 @@ namespace UnitTests.V1.UseCase
             Assert.IsInstanceOf<Transaction>(results.Transactions.First());
 
             Assert.IsInstanceOf<ListTransactionsRequest>(results.Request);
-            Assert.AreEqual(propertyRef, results.Request.PropertyRef);
+            Assert.AreEqual(tagRef, results.Request.TagRef);
         }
 
         [Test]
         public void ExecuteCallsTransactionGateway()
         {
-            var propertyRef = _faker.Random.Hash();
+            var tagRef = _faker.Random.Hash();
 
-            var request = new ListTransactionsRequest {PropertyRef = propertyRef};
+            var request = new ListTransactionsRequest {TagRef = tagRef};
 
             _classUnderTest.Execute(request);
 
-            _transactionsGateway.Verify(gateway => gateway.GetTransactionsByPropertyRef(propertyRef));
+            _transactionsGateway.Verify(gateway => gateway.GetTransactionsByTagRef(tagRef));
         }
 
         [Test]
         public void ExecuteReturnsResponceUsingGatewayResults()
         {
-            var propertyRef = _faker.Random.Hash();
+            var tagRef = _faker.Random.Hash();
 
-            var request = new ListTransactionsRequest {PropertyRef = propertyRef};
+            var request = new ListTransactionsRequest {TagRef = tagRef};
 
             List<Transaction> response = new List<Transaction>{ new Transaction(), new Transaction()};
 
-            _transactionsGateway.Setup(foo => foo.GetTransactionsByPropertyRef(propertyRef)).Returns(response);
+            _transactionsGateway.Setup(foo => foo.GetTransactionsByTagRef(tagRef)).Returns(response);
 
             var result = _classUnderTest.Execute(request);
 
@@ -87,15 +87,15 @@ namespace UnitTests.V1.UseCase
         [TestCase("asdasdas")]
         public void ExecuteReturnsOBjectWithRunningBalancePopulated(string propRef)
         {
-            var propertyRef = propRef;
-            var request = new ListTransactionsRequest(){PropertyRef = propertyRef};
+            var tagRef = propRef;
+            var request = new ListTransactionsRequest(){TagRef = tagRef};
 
             Transaction transactionA = TransactionHelper.CreateTransaction();
             Transaction transactionB = TransactionHelper.CreateTransaction();
 
             List<Transaction> listOfTransactions = new List<Transaction>() { transactionA, transactionB };
 
-            _transactionsGateway.Setup(x => x.GetTransactionsByPropertyRef(propertyRef)).Returns(listOfTransactions);
+            _transactionsGateway.Setup(x => x.GetTransactionsByTagRef(tagRef)).Returns(listOfTransactions);
 
             listOfTransactions = listOfTransactions?.CalculateRunningBalance();
 
@@ -107,10 +107,10 @@ namespace UnitTests.V1.UseCase
         [Test]
         public void ExecuteReturnsOBjectWithRunningBalanceUnPopulated()
         {
-            var propertyRef = _faker.Random.Hash(9);
-            var request = new ListTransactionsRequest() { PropertyRef = propertyRef };
+            var tagRef = _faker.Random.Hash(9);
+            var request = new ListTransactionsRequest() { TagRef = tagRef };
 
-            _transactionsGateway.Setup(x => x.GetTransactionsByPropertyRef(propertyRef)).Returns(()=>null);
+            _transactionsGateway.Setup(x => x.GetTransactionsByTagRef(tagRef)).Returns(()=>null);
 
             var expectedResult = _classUnderTest.Execute(request);
 

--- a/transactions-api/V1/Boundary/ListTransactionsRequest.cs
+++ b/transactions-api/V1/Boundary/ListTransactionsRequest.cs
@@ -6,6 +6,6 @@ namespace transactions_api.V1.Boundary
 {
     public class ListTransactionsRequest
     {
-        [Required] public string PropertyRef { get; set; }
+        [Required] public string TagRef { get; set; }
     }
 }

--- a/transactions-api/V1/Controllers/TransactionsController.cs
+++ b/transactions-api/V1/Controllers/TransactionsController.cs
@@ -23,7 +23,7 @@ namespace transactions_api.Controllers.V1
         [HttpGet]
         public JsonResult GetTransactions([FromQuery]ListTransactionsRequest request)
         {
-            _logger.LogInformation("Transactions requested for PropertyRef: " + request.PropertyRef);
+            _logger.LogInformation("Transactions requested for TagRef: " + request.TagRef);
             var usecaseResponce = _listTransactions.Execute(request);
             return new JsonResult(usecaseResponce) {StatusCode = 200};
         }

--- a/transactions-api/V1/Gateways/ITransactionsGateway.cs
+++ b/transactions-api/V1/Gateways/ITransactionsGateway.cs
@@ -5,6 +5,6 @@ namespace UnitTests.V1.Gateways
 {
     public interface ITransactionsGateway
     {
-        List<Transaction> GetTransactionsByPropertyRef(string propertyRef);
+        List<Transaction> GetTransactionsByTagRef(string propertyRef);
     }
 }

--- a/transactions-api/V1/Gateways/TransactionsGateway.cs
+++ b/transactions-api/V1/Gateways/TransactionsGateway.cs
@@ -22,7 +22,7 @@ namespace UnitTests.V1.Gateways
             _uhcontext = uhcontext;
         }
 
-        public List<Transaction> GetTransactionsByPropertyRef(string propertyRef)
+        public List<Transaction> GetTransactionsByTagRef(string tagRef)
         {
             var result = (from rtrans in _uhcontext.UTransactions
                           join debtype in _uhcontext.DebType
@@ -31,7 +31,7 @@ namespace UnitTests.V1.Gateways
                           join rectype in _uhcontext.RecType
                               on rtrans.Code equals rectype.rec_code into rc
                           from reccode in rc.DefaultIfEmpty()
-                          where rtrans.PropRef == propertyRef
+                          where rtrans.TagRef == tagRef
                           orderby rtrans.Date ascending
                           select new Transaction()
                           {

--- a/transactions-api/V1/Infrastructure/UhTransaction.cs
+++ b/transactions-api/V1/Infrastructure/UhTransaction.cs
@@ -26,6 +26,7 @@ namespace transactions_api.V1.Domain
         [Column("post_year")] public int FinancialYear { get; set; }
         [Column("post_prdno")] public Decimal PeriodNumber { get; set; }
         [Column("post_comm")] public string Comments { get; set; }
+        [Column("vat")] public Boolean vat { get; set; }
 
         public override bool Equals(object obj)
         {

--- a/transactions-api/V1/UseCase/ListTransactionsUsecase.cs
+++ b/transactions-api/V1/UseCase/ListTransactionsUsecase.cs
@@ -16,7 +16,7 @@ namespace transactions_api.UseCase
 
         public ListTransactionsResponse Execute(ListTransactionsRequest listTransactionsRequest)
         {
-            var results = _transactionsGateway.GetTransactionsByPropertyRef(listTransactionsRequest.PropertyRef);
+            var results = _transactionsGateway.GetTransactionsByTagRef(listTransactionsRequest.TagRef);
 
             results = results?.CalculateRunningBalance();
 


### PR DESCRIPTION
As per new requirements, the query parameter has changed from prop ref to tag ref. Replaced all the occurrences of prop ref to tag ref.

- Prop ref has been replaced with tag ref 
- Added vat field to UH transaction object as the simulator has it as a field and is a non-null field so it requires a value to be passed