### PR TITLE
rename circleci variables

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,8 +24,8 @@ commands:
           command: |
             ecs deploy \
             --no-deregister \
-            --access-key-id $AWS_ID_KEY \
-            --secret-access-key $AWS_SECRET_KEY \
+            --access-key-id $AWS_ACCESS_KEY_ID \
+            --secret-access-key $AWS_SECRET_ACCESS_KEY \
             --timeout 1800 \
             --region $AWS_REGION \
             << parameters.cluster-name >> \
@@ -41,8 +41,8 @@ jobs:
       - checkout
       - aws-cli/install
       - aws-cli/configure:
-          aws-access-key-id: AWS_ID_KEY
-          aws-secret-access-key: AWS_SECRET_KEY
+          aws-access-key-id: AWS_ACCESS_KEY_ID
+          aws-secret-access-key: AWS_SECRET_ACCESS_KEY
           aws-region: AWS_REGION
       - aws-ecr/ecr-login
       - setup_remote_docker
@@ -90,8 +90,8 @@ workflows:
           path: ./transactions-api
           account-url: AWS_ECR_HOST
           repo: $AWS_ECR_PATH
-          aws-access-key-id: AWS_ID_KEY
-          aws-secret-access-key: AWS_SECRET_KEY
+          aws-access-key-id: AWS_ACCESS_KEY_ID
+          aws-secret-access-key: AWS_SECRET_ACCESS_KEY
           region: AWS_REGION
           tag: "${CIRCLE_SHA1}"
           filters:


### PR DESCRIPTION
The CI variables for authenticating have been renamed for being consistent across projects. This will help when using a script for updating the environment variables in CircleCi.
