### PR TITLE
Feature get all tenancy transactions ncc endpoint port

### DIFF
--- a/transactions-api.Tests/V1/Controllers/TransactionsControllerTests.cs
+++ b/transactions-api.Tests/V1/Controllers/TransactionsControllerTests.cs
@@ -10,7 +10,11 @@ using NUnit.Framework;
 using transactions_api.Controllers.V1;
 using transactions_api.V1.Boundary;
 using transactions_api.V1.Domain;
+using transactions_api.V1.Validation;
 using UnitTests.V1.Helper;
+using FluentValidation.Results;
+using FV = FluentValidation.Results;
+using transactions_api.V1.Exceptions;
 
 namespace UnitTests.V1.Controllers
 {
@@ -21,16 +25,17 @@ namespace UnitTests.V1.Controllers
         private TransactionsController _classUnderTest;
 
         private Mock<IListTransactions> _mockListTransacionsUsecase;
+        private Mock<IGetTenancyTransactionsValidator> _mockGetTenancyTransactionsValidator;
 
-        private Faker faker = new Faker();
+        private Faker _faker = new Faker("en_GB");
 
         [SetUp]
         public void SetUp()
         {
             _mockListTransacionsUsecase = new Mock<IListTransactions>();
-
+            _mockGetTenancyTransactionsValidator = new Mock<IGetTenancyTransactionsValidator>();
             ILogger<TransactionsController> nullLogger = NullLogger<TransactionsController>.Instance;
-            _classUnderTest = new TransactionsController(_mockListTransacionsUsecase.Object, nullLogger);
+            _classUnderTest = new TransactionsController(_mockListTransacionsUsecase.Object, nullLogger, _mockGetTenancyTransactionsValidator.Object);
         }
 
         #region Transactions in General
@@ -40,7 +45,7 @@ namespace UnitTests.V1.Controllers
         {
             var transaction = TransactionHelper.CreateTransaction();
             var request = ListTransactionsRequest();
-            var datetime = faker.Date.Past();
+            var datetime = _faker.Date.Past();
 
             _mockListTransacionsUsecase.Setup(s =>
                     s.Execute(It.IsAny<ListTransactionsRequest>()))
@@ -78,11 +83,11 @@ namespace UnitTests.V1.Controllers
 
         private static ListTransactionsRequest ListTransactionsRequest()
         {
-            var faker = new Faker();
+            var _faker = new Faker();
             var listTransactionsRequest = new ListTransactionsRequest
             {
-                TagRef = faker.Random.Hash(9),
-                fromDate = faker.Date.Past(),
+                TagRef = _faker.Random.Hash(9),
+                fromDate = _faker.Date.Past(),
                 toDate = DateTime.Now
             };
             return listTransactionsRequest;
@@ -152,11 +157,30 @@ namespace UnitTests.V1.Controllers
         #region Tenancy Transactions
 
         [Test]
-        public void given_a_valid_input_when_GetAllTenancyTransactions_controller_method_is_called_then_it_returns_200_Ok_result()
+        public void given_a_request_object_when_GetAllTenancyTransactions_controller_method_is_called_then_it_calls_the_validator_with_that_request_object()
+        {
+            //arrange
+            var request = new GetAllTenancyTransactionsRequest()
+            {
+                PaymentRef = _faker.Random.Hash(),
+                PostCode = _faker.Address.ZipCode()
+            };
+
+            _mockGetTenancyTransactionsValidator.Setup(x => x.Validate(It.IsAny<GetAllTenancyTransactionsRequest>())).Returns(new FV.ValidationResult()); //setup validator to return a no error validation result
+
+            //act
+            _classUnderTest.GetAllTenancyTransactions(request);
+
+            //assert
+            _mockGetTenancyTransactionsValidator.Verify(v => v.Validate(It.Is<GetAllTenancyTransactionsRequest>(obj => obj == request)), Times.Once);
+        }
+
+        [Test]
+        public void given_a_valid_request_when_GetAllTenancyTransactions_controller_method_is_called_then_it_returns_200_Ok_result()
         {
             //arrange
             var expectedStatusCode = 200;
-            //TODO: Add validator mock setup to return no errors, when one is created!
+            _mockGetTenancyTransactionsValidator.Setup(v => v.Validate(It.IsAny<GetAllTenancyTransactionsRequest>())).Returns(new FV.ValidationResult()); //mock validator says it found no errors
 
             //act
             var controllerResponse = _classUnderTest.GetAllTenancyTransactions(new GetAllTenancyTransactionsRequest());
@@ -167,6 +191,67 @@ namespace UnitTests.V1.Controllers
             Assert.NotNull(result);
             Assert.IsInstanceOf<OkObjectResult>(result);
             Assert.AreEqual(expectedStatusCode, result.StatusCode);
+        }
+
+        [Test]
+        public void given_an_invalid_request_when_GetAllTenancyTransactions_controller_method_is_called_then_it_returns_400_Bad_Request_result()
+        {
+            //arrange
+            var expectedStatusCode = 400;
+            var request = new GetAllTenancyTransactionsRequest();                                                                                       //an empty request will be invalid
+
+            int errorCount = _faker.Random.Int(1, 10);                                                                                                  //simulate from 1 to 10 validation errors (triangulation).
+            var validationErrorList = new List<ValidationFailure>();                                                                                    //this list will be used as constructor argument for 'ValidationResult'.
+            for (int i = errorCount; i > 0; i--) { validationErrorList.Add(new ValidationFailure(_faker.Random.Word(), _faker.Random.Word())); }        //generate from 1 to 10 fake validation errors. Single line for-loop so that it wouldn't distract from what's key in this test.
+
+            var fakeValidationResult = new FV.ValidationResult(validationErrorList);                                                                    //Need to create ValidationResult so that I could setup Validator mock to return it upon '.Validate()' call. Also this is the only place where it's possible to manipulate the validation result - You can only make the validation result invalid by inserting a list of validation errors as a parameter through a constructor. The boolean '.IsValid' comes from expression 'IsValid => Errors.Count == 0;', so it can't be set manually.
+            _mockGetTenancyTransactionsValidator.Setup(v => v.Validate(It.IsAny<GetAllTenancyTransactionsRequest>())).Returns(fakeValidationResult);    //mock validator says that it has found errors
+
+            //act
+            var controllerResponse = _classUnderTest.GetAllTenancyTransactions(request);
+            var result = controllerResponse as ObjectResult;
+
+            //assert
+            Assert.NotNull(controllerResponse);
+            Assert.NotNull(result);
+            Assert.IsInstanceOf<BadRequestObjectResult>(result);
+            Assert.AreEqual(expectedStatusCode, result.StatusCode);
+        }
+
+        [Test]
+        public void given_an_invalid_request_when_GetAllTenancyTransactions_controller_method_is_called_then_returned_BadRequestObjectResult_contains_correctly_formatter_error_response()
+        {
+            //arrange
+            var expectedStatusCode = 400;
+            var request = new GetAllTenancyTransactionsRequest();                                                                                       //an empty request will be invalid
+
+            int errorCount = _faker.Random.Int(1, 10);                                                                                                  //simulate from 1 to 10 validation errors (triangulation).
+            var validationErrorList = new List<ValidationFailure>();                                                                                    //this list will be used as constructor argument for 'ValidationResult'.
+            for (int i = errorCount; i > 0; i--) { validationErrorList.Add(new ValidationFailure(_faker.Random.Word(), _faker.Random.Word())); }        //generate from 1 to 10 fake validation errors. Single line for-loop so that it wouldn't distract from what's key in this test.
+
+            var fakeValidationResult = new FV.ValidationResult(validationErrorList);                                                                    //Need to create ValidationResult so that I could setup Validator mock to return it upon '.Validate()' call. Also this is the only place where it's possible to manipulate the validation result - You can only make the validation result invalid by inserting a list of validation errors as a parameter through a constructor. The boolean '.IsValid' comes from expression 'IsValid => Errors.Count == 0;', so it can't be set manually.
+            _mockGetTenancyTransactionsValidator.Setup(v => v.Validate(It.IsAny<GetAllTenancyTransactionsRequest>())).Returns(fakeValidationResult);    //mock validator says that it has found errors
+
+            var expectedControllerResponse = new BadRequestObjectResult(validationErrorList);                                                           //build up expected controller response to check if the contents of the errors match - that's probably the easiest way to check that.
+
+            //act
+            var controllerResponse = _classUnderTest.GetAllTenancyTransactions(request);
+            var result = controllerResponse as ObjectResult;
+            var errorResponse = result.Value as ErrorResponse;
+
+            //assert
+            Assert.NotNull(result);
+
+            Assert.IsInstanceOf<ErrorResponse>(result.Value);
+            Assert.NotNull(result.Value);
+
+            Assert.IsInstanceOf<string>(errorResponse.status);
+            Assert.NotNull(errorResponse.status);
+            Assert.AreEqual("fail", errorResponse.status);
+
+            Assert.IsInstanceOf<List<string>>(errorResponse.errors);
+            Assert.NotNull(errorResponse.errors);
+            Assert.AreEqual(errorCount, errorResponse.errors.Count);
         }
 
         #endregion

--- a/transactions-api.Tests/V1/Controllers/TransactionsControllerTests.cs
+++ b/transactions-api.Tests/V1/Controllers/TransactionsControllerTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Bogus;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
@@ -31,6 +32,8 @@ namespace UnitTests.V1.Controllers
             ILogger<TransactionsController> nullLogger = NullLogger<TransactionsController>.Instance;
             _classUnderTest = new TransactionsController(_mockListTransacionsUsecase.Object, nullLogger);
         }
+
+        #region Transactions in General
 
         [Test]
         public void ReturnsCorrectRandomResponseWithStatus()
@@ -143,5 +146,29 @@ namespace UnitTests.V1.Controllers
 }";
             return json;
         }
+
+        #endregion
+
+        #region Tenancy Transactions
+
+        [Test]
+        public void given_a_valid_input_when_GetAllTenancyTransactions_controller_method_is_called_then_it_returns_200_Ok_result()
+        {
+            //arrange
+            var expectedStatusCode = 200;
+            //TODO: Add validator mock setup to return no errors, when one is created!
+
+            //act
+            var controllerResponse = _classUnderTest.GetAllTenancyTransactions(new GetAllTenancyTransactionsRequest());
+            var result = controllerResponse as ObjectResult;
+
+            //assert
+            Assert.NotNull(controllerResponse);
+            Assert.NotNull(result);
+            Assert.IsInstanceOf<OkObjectResult>(result);
+            Assert.AreEqual(expectedStatusCode, result.StatusCode);
+        }
+
+        #endregion
     }
 }

--- a/transactions-api.Tests/V1/Controllers/TransactionsControllerTests.cs
+++ b/transactions-api.Tests/V1/Controllers/TransactionsControllerTests.cs
@@ -236,6 +236,74 @@ namespace UnitTests.V1.Controllers
             Assert.AreEqual(fakeValidationResult.Errors.Count, errorResponse.errors.Count);
         }
 
+        [Test]
+        public void given_successful_request_validation_when_GetAllTenancyTransactions_controller_method_is_called_then_it_calls_usecase()
+        {
+            //arrange
+            _mockGetTenancyTransactionsValidator.Setup(x => x.Validate(It.IsAny<GetAllTenancyTransactionsRequest>())).Returns(TransactionHelper.GenerateSuccessValidationResult()); //setup validator to return a no error validation result
+
+            //act
+            _classUnderTest.GetAllTenancyTransactions(new GetAllTenancyTransactionsRequest());
+
+            //assert
+            _mockListTransacionsUsecase.Verify(u => u.ExecuteGetTenancyTransactions(It.IsAny<GetAllTenancyTransactionsRequest>()), Times.Once);
+        }
+
+        [Test]
+        public void given_successful_request_validation_when_GetAllTenancyTransactions_controller_method_is_called_then_it_calls_usecase_with_corresponding_request_object()
+        {
+            //arrange
+            var expectedRequest = TransactionHelper.CreateGetAllTenancyTransactionsRequestObject();
+            _mockGetTenancyTransactionsValidator.Setup(x => x.Validate(It.IsAny<GetAllTenancyTransactionsRequest>())).Returns(TransactionHelper.GenerateSuccessValidationResult()); //setup validator to return a no error validation result
+
+            //act
+            _classUnderTest.GetAllTenancyTransactions(expectedRequest);
+
+            //assert
+            _mockListTransacionsUsecase.Verify(
+                u => u.ExecuteGetTenancyTransactions(
+                    It.Is<GetAllTenancyTransactionsRequest>(
+                        r =>
+                            r.PaymentRef == expectedRequest.PaymentRef &&
+                            r.PostCode   == expectedRequest.PostCode
+                    )
+                ),Times.Once);
+        }
+
+        [Test]
+        public void given_unsuccessful_request_validation_when_GetAllTenancyTransactions_controller_method_is_called_then_it_does_not_call_usecase()
+        {
+            //arrange
+            _mockGetTenancyTransactionsValidator.Setup(x => x.Validate(It.IsAny<GetAllTenancyTransactionsRequest>())).Returns(TransactionHelper.GenerateFailedValidationResult()); //setup validator to return a no error validation result
+
+            //act
+            _classUnderTest.GetAllTenancyTransactions(new GetAllTenancyTransactionsRequest());
+
+            //assert
+            _mockListTransacionsUsecase.Verify(u => u.ExecuteGetTenancyTransactions(It.IsAny<GetAllTenancyTransactionsRequest>()), Times.Never);
+        }
+
+        [Test]
+        public void given_successful_request_validation_when_GetAllTenancyTransactions_controller_method_is_called_it_returns_the_same_object_usecase_returned()                    //but wrapped up - no point in saying in test name, since there are other tests that check wrapping up
+        {
+            //arrange
+            var expectedResponse = TransactionHelper.CreateGetAllTenancyTransactionsResponseObject();
+            _mockListTransacionsUsecase.Setup(u => u.ExecuteGetTenancyTransactions(It.IsAny<GetAllTenancyTransactionsRequest>())).Returns(expectedResponse);
+            _mockGetTenancyTransactionsValidator.Setup(x => x.Validate(It.IsAny<GetAllTenancyTransactionsRequest>())).Returns(TransactionHelper.GenerateSuccessValidationResult());
+
+            //act
+            var controllerResponse = _classUnderTest.GetAllTenancyTransactions(new GetAllTenancyTransactionsRequest());
+            var controllerResult = controllerResponse as ObjectResult;
+            var actualResponse = controllerResult.Value as GetAllTenancyTransactionsResponse;
+
+            //assert
+            Assert.NotNull(controllerResponse);
+            Assert.NotNull(controllerResult);
+            Assert.NotNull(actualResponse);
+
+            Assert.AreSame(expectedResponse, actualResponse);                                                                                                                       //if they're the same object, then it means that controller is indeed simply wrapping up and passing back whatever the usecase returns
+        }
+
         #endregion
     }
 }

--- a/transactions-api.Tests/V1/Controllers/TransactionsControllerTests.cs
+++ b/transactions-api.Tests/V1/Controllers/TransactionsControllerTests.cs
@@ -160,11 +160,7 @@ namespace UnitTests.V1.Controllers
         public void given_a_request_object_when_GetAllTenancyTransactions_controller_method_is_called_then_it_calls_the_validator_with_that_request_object()
         {
             //arrange
-            var request = new GetAllTenancyTransactionsRequest()
-            {
-                PaymentRef = _faker.Random.Hash(),
-                PostCode = _faker.Address.ZipCode()
-            };
+            var request = TransactionHelper.CreateGetAllTenancyTransactionsRequestObject();
 
             _mockGetTenancyTransactionsValidator.Setup(x => x.Validate(It.IsAny<GetAllTenancyTransactionsRequest>())).Returns(new FV.ValidationResult()); //setup validator to return a no error validation result
 

--- a/transactions-api.Tests/V1/Controllers/TransactionsControllerTests.cs
+++ b/transactions-api.Tests/V1/Controllers/TransactionsControllerTests.cs
@@ -162,7 +162,7 @@ namespace UnitTests.V1.Controllers
             //arrange
             var request = TransactionHelper.CreateGetAllTenancyTransactionsRequestObject();
 
-            _mockGetTenancyTransactionsValidator.Setup(x => x.Validate(It.IsAny<GetAllTenancyTransactionsRequest>())).Returns(new FV.ValidationResult()); //setup validator to return a no error validation result
+            _mockGetTenancyTransactionsValidator.Setup(x => x.Validate(It.IsAny<GetAllTenancyTransactionsRequest>())).Returns(TransactionHelper.GenerateSuccessValidationResult());
 
             //act
             _classUnderTest.GetAllTenancyTransactions(request);
@@ -176,7 +176,7 @@ namespace UnitTests.V1.Controllers
         {
             //arrange
             var expectedStatusCode = 200;
-            _mockGetTenancyTransactionsValidator.Setup(v => v.Validate(It.IsAny<GetAllTenancyTransactionsRequest>())).Returns(new FV.ValidationResult()); //mock validator says it found no errors
+            _mockGetTenancyTransactionsValidator.Setup(v => v.Validate(It.IsAny<GetAllTenancyTransactionsRequest>())).Returns(TransactionHelper.GenerateSuccessValidationResult());
 
             //act
             var controllerResponse = _classUnderTest.GetAllTenancyTransactions(new GetAllTenancyTransactionsRequest());
@@ -194,17 +194,12 @@ namespace UnitTests.V1.Controllers
         {
             //arrange
             var expectedStatusCode = 400;
-            var request = new GetAllTenancyTransactionsRequest();                                                                                       //an empty request will be invalid
 
-            int errorCount = _faker.Random.Int(1, 10);                                                                                                  //simulate from 1 to 10 validation errors (triangulation).
-            var validationErrorList = new List<ValidationFailure>();                                                                                    //this list will be used as constructor argument for 'ValidationResult'.
-            for (int i = errorCount; i > 0; i--) { validationErrorList.Add(new ValidationFailure(_faker.Random.Word(), _faker.Random.Word())); }        //generate from 1 to 10 fake validation errors. Single line for-loop so that it wouldn't distract from what's key in this test.
-
-            var fakeValidationResult = new FV.ValidationResult(validationErrorList);                                                                    //Need to create ValidationResult so that I could setup Validator mock to return it upon '.Validate()' call. Also this is the only place where it's possible to manipulate the validation result - You can only make the validation result invalid by inserting a list of validation errors as a parameter through a constructor. The boolean '.IsValid' comes from expression 'IsValid => Errors.Count == 0;', so it can't be set manually.
+            var fakeValidationResult = TransactionHelper.GenerateFailedValidationResult();
             _mockGetTenancyTransactionsValidator.Setup(v => v.Validate(It.IsAny<GetAllTenancyTransactionsRequest>())).Returns(fakeValidationResult);    //mock validator says that it has found errors
 
             //act
-            var controllerResponse = _classUnderTest.GetAllTenancyTransactions(request);
+            var controllerResponse = _classUnderTest.GetAllTenancyTransactions(new GetAllTenancyTransactionsRequest());
             var result = controllerResponse as ObjectResult;
 
             //assert
@@ -218,20 +213,11 @@ namespace UnitTests.V1.Controllers
         public void given_an_invalid_request_when_GetAllTenancyTransactions_controller_method_is_called_then_returned_BadRequestObjectResult_contains_correctly_formatter_error_response()
         {
             //arrange
-            var expectedStatusCode = 400;
-            var request = new GetAllTenancyTransactionsRequest();                                                                                       //an empty request will be invalid
-
-            int errorCount = _faker.Random.Int(1, 10);                                                                                                  //simulate from 1 to 10 validation errors (triangulation).
-            var validationErrorList = new List<ValidationFailure>();                                                                                    //this list will be used as constructor argument for 'ValidationResult'.
-            for (int i = errorCount; i > 0; i--) { validationErrorList.Add(new ValidationFailure(_faker.Random.Word(), _faker.Random.Word())); }        //generate from 1 to 10 fake validation errors. Single line for-loop so that it wouldn't distract from what's key in this test.
-
-            var fakeValidationResult = new FV.ValidationResult(validationErrorList);                                                                    //Need to create ValidationResult so that I could setup Validator mock to return it upon '.Validate()' call. Also this is the only place where it's possible to manipulate the validation result - You can only make the validation result invalid by inserting a list of validation errors as a parameter through a constructor. The boolean '.IsValid' comes from expression 'IsValid => Errors.Count == 0;', so it can't be set manually.
+            var fakeValidationResult = TransactionHelper.GenerateFailedValidationResult();
             _mockGetTenancyTransactionsValidator.Setup(v => v.Validate(It.IsAny<GetAllTenancyTransactionsRequest>())).Returns(fakeValidationResult);    //mock validator says that it has found errors
 
-            var expectedControllerResponse = new BadRequestObjectResult(validationErrorList);                                                           //build up expected controller response to check if the contents of the errors match - that's probably the easiest way to check that.
-
             //act
-            var controllerResponse = _classUnderTest.GetAllTenancyTransactions(request);
+            var controllerResponse = _classUnderTest.GetAllTenancyTransactions(new GetAllTenancyTransactionsRequest());
             var result = controllerResponse as ObjectResult;
             var errorResponse = result.Value as ErrorResponse;
 
@@ -247,7 +233,7 @@ namespace UnitTests.V1.Controllers
 
             Assert.IsInstanceOf<List<string>>(errorResponse.errors);
             Assert.NotNull(errorResponse.errors);
-            Assert.AreEqual(errorCount, errorResponse.errors.Count);
+            Assert.AreEqual(fakeValidationResult.Errors.Count, errorResponse.errors.Count);
         }
 
         #endregion

--- a/transactions-api.Tests/V1/Exceptions/ErrorResponseTests.cs
+++ b/transactions-api.Tests/V1/Exceptions/ErrorResponseTests.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentValidation.Results;
+using FV = FluentValidation.Results;
+using Bogus;
+using transactions_api.V1.Exceptions;
+using NUnit.Framework;
+using transactions_api.V1.Helpers;
+
+namespace transactions_api.Tests.V1.Exceptions
+{
+    [TestFixture]
+    public class ErrorResponseTests
+    {
+        private Faker _faker = new Faker();
+
+        [Test]
+        public void given_no_parameters_when_ErrorResponse_constructor_is_called_then_it_initializes_errors_parameter_to_empty_list()
+        {
+            //act
+            var errorResponse = new ErrorResponse();
+
+            //assert
+            Assert.NotNull(errorResponse.errors);
+            Assert.Zero(errorResponse.errors.Count);
+        }
+
+        [Test]
+        public void given_a_list_of_error_strings_when_ErrorResponse_constructor_is_called_then_it_initializes_errors_parameter_to_passed_in_list_of_errors()
+        {
+            //arrange
+            var expectedListOfErrors = new List<string>();
+
+            for (int i = _faker.Random.Int(1, 10); i > 0; i--)
+                expectedListOfErrors.Add(_faker.Random.Hash());
+
+            //act
+            var errorResponse = new ErrorResponse(expectedListOfErrors);
+            var actualListOfErrors = errorResponse.errors;
+
+            //assert
+            Assert.NotNull(actualListOfErrors);
+            Assert.AreSame(expectedListOfErrors, actualListOfErrors); //they should have the same obj reference
+        }
+
+        [Test]
+        public void given_any_number_of_error_string_parameters_when_ErrorResponse_constructor_is_called_then_it_initializes_errors_parameter_to_a_list_of_error_strings_corresponding_to_passed_in_parameters()
+        {
+            //act
+            var singleParameterErrorResponse = new ErrorResponse( _faker.Random.Word() );
+            var fourParameterErrorResponse = new ErrorResponse( _faker.Random.Word(), _faker.Random.Word(), _faker.Random.Word(), _faker.Random.Word() );
+            var sevenParameterErrorResponse = new ErrorResponse( _faker.Random.Word(), _faker.Random.Word(), _faker.Random.Word(), _faker.Random.Word(), _faker.Random.Word(), _faker.Random.Word(), _faker.Random.Word() );
+
+            //assert
+            Assert.AreEqual(1, singleParameterErrorResponse.errors.Count);
+            Assert.AreEqual(4, fourParameterErrorResponse.errors.Count);
+            Assert.AreEqual(7, sevenParameterErrorResponse.errors.Count);
+        }
+
+        [Test]
+        public void given_a_list_of_validation_failures_when_ErrorResponse_constructor_is_called_then_it_initializes_errors_parameter_to_a_list_of_error_messages()
+        {
+            //arrange
+            int errorCount = _faker.Random.Int(1, 10);                                                                                                     //simulate from 1 to 10 validation errors (triangulation).
+            var validationFailuresList = new List<ValidationFailure>();                                                                                    //this list will be used as constructor argument for 'ValidationResult'.
+            for (int i = errorCount; i > 0; i--) { validationFailuresList.Add(new ValidationFailure(_faker.Random.Word(), _faker.Random.Word())); }        //generate from 1 to 10 fake validation errors. Single line for-loop so that it wouldn't distract from what's key in this test.
+
+            //act
+            var errorResponse = new ErrorResponse(validationFailuresList);
+
+            //assert
+            Assert.AreEqual(errorCount, errorResponse.errors.Count);
+        }
+    }
+}

--- a/transactions-api.Tests/V1/Exceptions/ErrorResponseTests.cs
+++ b/transactions-api.Tests/V1/Exceptions/ErrorResponseTests.cs
@@ -8,6 +8,7 @@ using Bogus;
 using transactions_api.V1.Exceptions;
 using NUnit.Framework;
 using transactions_api.V1.Helpers;
+using UnitTests.V1.Helper;
 
 namespace transactions_api.Tests.V1.Exceptions
 {
@@ -63,15 +64,14 @@ namespace transactions_api.Tests.V1.Exceptions
         public void given_a_list_of_validation_failures_when_ErrorResponse_constructor_is_called_then_it_initializes_errors_parameter_to_a_list_of_error_messages()
         {
             //arrange
-            int errorCount = _faker.Random.Int(1, 10);                                                                                                     //simulate from 1 to 10 validation errors (triangulation).
-            var validationFailuresList = new List<ValidationFailure>();                                                                                    //this list will be used as constructor argument for 'ValidationResult'.
-            for (int i = errorCount; i > 0; i--) { validationFailuresList.Add(new ValidationFailure(_faker.Random.Word(), _faker.Random.Word())); }        //generate from 1 to 10 fake validation errors. Single line for-loop so that it wouldn't distract from what's key in this test.
+            var validationFailuresList = TransactionHelper.GenerateAListOfValidationFailures();
 
             //act
             var errorResponse = new ErrorResponse(validationFailuresList);
 
             //assert
-            Assert.AreEqual(errorCount, errorResponse.errors.Count);
+            Assert.IsInstanceOf<List<string>>(errorResponse.errors);
+            Assert.AreEqual(validationFailuresList.Count, errorResponse.errors.Count);
         }
     }
 }

--- a/transactions-api.Tests/V1/Gateways/TransactionsGatewayTests.cs
+++ b/transactions-api.Tests/V1/Gateways/TransactionsGatewayTests.cs
@@ -19,6 +19,8 @@ namespace UnitTests.V1.Gateways
             _classUnderTest = new TransactionsGateway(_uhContext);
         }
 
+        #region GetTransaction (in general)
+
         [Test]
         public void ListOfTransactionsImplementsBoundaryInterface()
         {
@@ -63,5 +65,14 @@ namespace UnitTests.V1.Gateways
             Assert.AreEqual(transaction.PeriodNumber,response.PeriodNumber);
             Assert.AreEqual(transaction.FinancialYear,response.FinancialYear);
         }
+
+        #endregion
+
+        #region GetTenancyTransactions
+
+        //Same here all of will need to be separated out for the sake of lowering responsibilities, also this will need to be rewritten to make use of EF Core.
+
+        #endregion
+
     }
 }

--- a/transactions-api.Tests/V1/Helper/ErrorMessagesFormatterTests.cs
+++ b/transactions-api.Tests/V1/Helper/ErrorMessagesFormatterTests.cs
@@ -1,0 +1,44 @@
+using FluentValidation.Results;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using transactions_api.V1.Helpers;
+using Bogus;
+
+namespace transactions_api.Tests.V1.Helper
+{
+    [TestFixture]
+    public class ErrorMessagesFormatterTests
+    {
+        private Faker _faker;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _faker = new Faker();
+        }
+
+        [Test]
+        public void given_a_list_of_validation_failures_when_FormatValidationFailures_error_formatter_method_is_called_then_it_returns_a_list_of_corresponding_error_messages() //we don't check the message format. we only check that the related text was given as output.
+        {
+            //arrange
+            int errorCount = _faker.Random.Int(1, 10);                                                                                                     //simulate from 1 to 10 validation errors (triangulation).
+            var validationFailuresList = new List<ValidationFailure>();                                                                                    //this list will be used as constructor argument for 'ValidationResult'.
+            for (int i = errorCount; i > 0; i--) { validationFailuresList.Add(new ValidationFailure(_faker.Random.Word(), _faker.Random.Word())); }        //generate from 1 to 10 fake validation errors. Single line for-loop so that it wouldn't distract from what's key in this test.
+
+            //act
+            var formattedList = ErrorMessagesFormatter.FormatValidationFailures(validationFailuresList);
+
+            //assert
+            Assert.AreEqual(errorCount, formattedList.Count);
+
+            for(int i = 0; i < errorCount ; i++)
+            {
+                StringAssert.Contains(validationFailuresList[i].PropertyName, formattedList[i]);
+                StringAssert.Contains(validationFailuresList[i].ErrorMessage, formattedList[i]);
+            }
+        }
+    }
+}

--- a/transactions-api.Tests/V1/Helper/ErrorMessagesFormatterTests.cs
+++ b/transactions-api.Tests/V1/Helper/ErrorMessagesFormatterTests.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using transactions_api.V1.Helpers;
 using Bogus;
+using UnitTests.V1.Helper;
 
 namespace transactions_api.Tests.V1.Helper
 {
@@ -24,9 +25,8 @@ namespace transactions_api.Tests.V1.Helper
         public void given_a_list_of_validation_failures_when_FormatValidationFailures_error_formatter_method_is_called_then_it_returns_a_list_of_corresponding_error_messages() //we don't check the message format. we only check that the related text was given as output.
         {
             //arrange
-            int errorCount = _faker.Random.Int(1, 10);                                                                                                     //simulate from 1 to 10 validation errors (triangulation).
-            var validationFailuresList = new List<ValidationFailure>();                                                                                    //this list will be used as constructor argument for 'ValidationResult'.
-            for (int i = errorCount; i > 0; i--) { validationFailuresList.Add(new ValidationFailure(_faker.Random.Word(), _faker.Random.Word())); }        //generate from 1 to 10 fake validation errors. Single line for-loop so that it wouldn't distract from what's key in this test.
+            var validationFailuresList = TransactionHelper.GenerateAListOfValidationFailures();
+            var errorCount = validationFailuresList.Count;
 
             //act
             var formattedList = ErrorMessagesFormatter.FormatValidationFailures(validationFailuresList);

--- a/transactions-api.Tests/V1/Helper/TransactionHelper.cs
+++ b/transactions-api.Tests/V1/Helper/TransactionHelper.cs
@@ -1,4 +1,7 @@
 using Bogus;
+using FluentValidation.Results;
+using FV = FluentValidation.Results;
+using System.Collections.Generic;
 using transactions_api.V1.Boundary;
 using transactions_api.V1.Domain;
 
@@ -32,5 +35,30 @@ namespace UnitTests.V1.Helper
                 PostCode = _faker.Address.ZipCode()
             };
         }
+
+
+        #region Fake Validation Results
+
+        public static List<ValidationFailure> GenerateAListOfValidationFailures()
+        {
+            int errorCount = _faker.Random.Int(1, 10);                                                                                                  //simulate from 1 to 10 validation errors (triangulation).
+            var validationErrorList = new List<ValidationFailure>();                                                                                    //this list will be used as constructor argument for 'ValidationResult'.
+            for (int i = errorCount; i > 0; i--) { validationErrorList.Add(new ValidationFailure(_faker.Random.Word(), _faker.Random.Word())); }        //generate from 1 to 10 fake validation errors. Single line for-loop so that it wouldn't distract from what's key in this test.
+
+            return validationErrorList;
+        }
+
+        public static FV.ValidationResult GenerateFailedValidationResult()
+        {
+            var validationErrorList = GenerateAListOfValidationFailures();
+            return new FV.ValidationResult(validationErrorList);                                                                                        //Need to create ValidationResult so that I could setup Validator mock to return it upon '.Validate()' call. Also this is the only place where it's possible to manipulate the validation result - You can only make the validation result invalid by inserting a list of validation errors as a parameter through a constructor. The boolean '.IsValid' comes from expression 'IsValid => Errors.Count == 0;', so it can't be set manually.
+        }
+
+        public static FV.ValidationResult GenerateSuccessValidationResult()
+        {
+            return new FV.ValidationResult();                                                                                                           //This is a success, because no validation failures were passed into the constructor. The boolean '.IsValid' comes from expression 'IsValid => Errors.Count == 0;', so it can't be set manually.
+        }
+
+        #endregion
     }
 }

--- a/transactions-api.Tests/V1/Helper/TransactionHelper.cs
+++ b/transactions-api.Tests/V1/Helper/TransactionHelper.cs
@@ -4,6 +4,7 @@ using FV = FluentValidation.Results;
 using System.Collections.Generic;
 using transactions_api.V1.Boundary;
 using transactions_api.V1.Domain;
+using System;
 
 namespace UnitTests.V1.Helper
 {
@@ -61,6 +62,8 @@ namespace UnitTests.V1.Helper
 
         #endregion
 
+        #region Create Random Request Objects
+
         public static GetAllTenancyTransactionsRequest CreateGetAllTenancyTransactionsRequestObject()
         {
             return new GetAllTenancyTransactionsRequest()
@@ -70,6 +73,22 @@ namespace UnitTests.V1.Helper
             };
         }
 
+        #endregion
+
+        #region Create Random Response Objects
+
+        public static GetAllTenancyTransactionsResponse CreateGetAllTenancyTransactionsResponseObject()
+        {
+            return new GetAllTenancyTransactionsResponse()
+            {
+                GeneratedAt = DateTime.Now,
+                Request = CreateGetAllTenancyTransactionsRequestObject(),
+                Transactions = CreateTenancyTransactionList(5),
+                CurrentBalance = _faker.Finance.Amount(-1000, 1000, 2).ToString()
+            };
+        }
+
+        #endregion
 
         #region Fake Validation Results
 

--- a/transactions-api.Tests/V1/Helper/TransactionHelper.cs
+++ b/transactions-api.Tests/V1/Helper/TransactionHelper.cs
@@ -60,6 +60,25 @@ namespace UnitTests.V1.Helper
             return transactions;
         }
 
+        public static TenancyAgreementDetails CreateTenancyAgreementDetails()
+        {
+            var balance = _faker.Finance.Amount(-2000, 2000, 2);
+
+            return new TenancyAgreementDetails()
+            {
+                CurrentBalance = balance.ToString(),
+                DisplayBalance = (-balance).ToString(),
+                Rent = _faker.Finance.Amount(100, 200, 2).ToString(),
+                StartDate = _faker.Date.Past().ToString("dd/MM/yyyy HH:mm:ss"),
+                HousingReferenceNumber = _faker.Random.Hash(),
+                PropertyReferenceNumber = _faker.Random.Hash(),
+                TenancyAgreementReference = _faker.Random.Hash(),
+                PaymentReferenceNumber = _faker.Random.Hash(),
+                IsAgreementTerminated = _faker.Random.Bool(),
+                TenureType = _faker.Random.Word()
+            };
+        }
+
         #endregion
 
         #region Create Random Request Objects
@@ -84,7 +103,7 @@ namespace UnitTests.V1.Helper
                 GeneratedAt = DateTime.Now,
                 Request = CreateGetAllTenancyTransactionsRequestObject(),
                 Transactions = CreateTenancyTransactionList(5),
-                CurrentBalance = _faker.Finance.Amount(-1000, 1000, 2).ToString()
+                TenancyDetails = CreateTenancyAgreementDetails()
             };
         }
 

--- a/transactions-api.Tests/V1/Helper/TransactionHelper.cs
+++ b/transactions-api.Tests/V1/Helper/TransactionHelper.cs
@@ -1,25 +1,36 @@
 using Bogus;
+using transactions_api.V1.Boundary;
 using transactions_api.V1.Domain;
 
 namespace UnitTests.V1.Helper
 {
-    public class TransactionHelper
+    public static class TransactionHelper
     {
+        private static Faker _faker = new Faker("en_GB");
+
         public static Transaction CreateTransaction()
         {
-            var faker = new Faker();
             var transaction = new Transaction
             {
-                Date = faker.Date.Past(),
-                Code = faker.Random.Hash(3),
-                Description = faker.Random.Hash(15),
-                Amount = faker.Finance.Amount(),
-                Comments = faker.Random.Hash(15),
-                FinancialYear = faker.Date.Past().Year,
-                PeriodNumber = faker.Random.Int(0,99),
-                RunningBalance = faker.Finance.Amount()
+                Date = _faker.Date.Past(),
+                Code = _faker.Random.Hash(3),
+                Description = _faker.Random.Hash(15),
+                Amount = _faker.Finance.Amount(),
+                Comments = _faker.Random.Hash(15),
+                FinancialYear = _faker.Date.Past().Year,
+                PeriodNumber = _faker.Random.Int(0,99),
+                RunningBalance = _faker.Finance.Amount()
             };
             return transaction;
+        }
+
+        public static GetAllTenancyTransactionsRequest CreateGetAllTenancyTransactionsRequestObject()
+        {
+            return new GetAllTenancyTransactionsRequest()
+            {
+                PaymentRef = _faker.Random.Hash(),
+                PostCode = _faker.Address.ZipCode()
+            };
         }
     }
 }

--- a/transactions-api.Tests/V1/Helper/TransactionHelper.cs
+++ b/transactions-api.Tests/V1/Helper/TransactionHelper.cs
@@ -11,6 +11,8 @@ namespace UnitTests.V1.Helper
     {
         private static Faker _faker = new Faker("en_GB");
 
+        #region Create Random Domain Object
+
         public static Transaction CreateTransaction()
         {
             var transaction = new Transaction
@@ -26,6 +28,38 @@ namespace UnitTests.V1.Helper
             };
             return transaction;
         }
+
+        private static TempTenancyTransaction CreateTempTenancyTransaction()                                    //Will need to change, once this port gets re-done properly.
+        {
+            return new TempTenancyTransaction()
+            {
+                Date = _faker.Date.Past().ToString("dd/MM/yyyy HH:mm:ss"),
+                Amount = _faker.Finance.Amount(-500, 500, 2).ToString(),
+                Type = _faker.Random.Word(),
+                Description = _faker.Random.Words(3)
+            };
+        }
+
+        public static List<TenancyTransaction> CreateTenancyTransactionList(int quantityMax)                     //Same here, this doesn't generate proper interconnected balances or anything, it just fill them in.
+        {
+            var transactions = new List<TenancyTransaction>();
+
+            for (int i = _faker.Random.Int(1, quantityMax); i > 0; i--)
+            {
+                var tempTransaction = CreateTempTenancyTransaction();
+                transactions.Add(new TenancyTransaction() {
+                    Balance = _faker.Finance.Amount(-2000, 2000, 2).ToString(),
+                    Date = tempTransaction.Date,
+                    Description = tempTransaction.Description,
+                    In = double.Parse(tempTransaction.Amount) >= 0 ? tempTransaction.Amount : null,
+                    Out = double.Parse(tempTransaction.Amount) >= 0 ? null : tempTransaction.Amount,
+                });
+            }
+
+            return transactions;
+        }
+
+        #endregion
 
         public static GetAllTenancyTransactionsRequest CreateGetAllTenancyTransactionsRequestObject()
         {

--- a/transactions-api.Tests/V1/UseCase/ListTransactionsUsecaseTests.cs
+++ b/transactions-api.Tests/V1/UseCase/ListTransactionsUsecaseTests.cs
@@ -33,6 +33,9 @@ namespace UnitTests.V1.UseCase
         {
             Assert.True(_classUnderTest is IListTransactions);
         }
+
+        #region GetTransactions (in general)
+
         [Test]
         public void CanGetListOfTransactionsByTagference()
         {
@@ -143,5 +146,13 @@ namespace UnitTests.V1.UseCase
 
             Assert.AreEqual(expectedResult.Transactions, listOfFilteredTransactions);
         }
+
+        #endregion
+
+        #region GetTenancyTransactions
+
+        // this is where TDD breaks down due to port being temp solution - will need to add tests in the future
+
+        #endregion
     }
 }

--- a/transactions-api.Tests/V1/Validation/GetTenancyTransactionsValidatorTests.cs
+++ b/transactions-api.Tests/V1/Validation/GetTenancyTransactionsValidatorTests.cs
@@ -1,0 +1,279 @@
+using FluentValidation.TestHelper;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using transactions_api.V1.Helpers;
+using transactions_api.V1.Validation;
+using UnitTests.V1.Helper;
+
+namespace transactions_api.Tests.V1.Validation
+{
+    [TestFixture]
+    public class GetTenancyTransactionsValidatorTests
+    {
+        private GetTenancyTransactionsValidator _validator;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _validator = new GetTenancyTransactionsValidator();
+        }
+
+        #region Field Is Required [Null]
+
+        [Test]
+        public void given_a_request_with_null_PaymentRef_when_GetTenancyTransactionsValidator_is_called_then_it_returns_an_error()
+        {
+            //arrange
+            var request = TransactionHelper.CreateGetAllTenancyTransactionsRequestObject();
+            request.PaymentRef = null;
+
+            //act, assert
+            _validator.ShouldHaveValidationErrorFor(req => req.PaymentRef, request).WithErrorMessage(ErrorMessagesFormatter.FieldIsNullMessage("Payment reference"));
+        }
+
+        [Test]
+        public void given_a_request_with_null_PostCode_when_GetTenancyTransactionsValidator_is_called_then_it_returns_an_error()
+        {
+            //arrange
+            var request = TransactionHelper.CreateGetAllTenancyTransactionsRequestObject();
+            request.PostCode = null;
+
+            //act, assert
+            _validator.ShouldHaveValidationErrorFor(req => req.PostCode, request).WithErrorMessage(ErrorMessagesFormatter.FieldIsNullMessage("Postcode"));
+        }
+
+        #endregion
+
+
+        #region Field is required [Whitespace or Empty]
+
+        [TestCase("")]
+        [TestCase(" ")]
+        public void given_a_request_with_empty_or_whitespace_PaymentRef_when_GetTenancyTransactionsValidator_is_called_then_it_returns_an_error(string paymentRef)
+        {
+            //arrange
+            var request = TransactionHelper.CreateGetAllTenancyTransactionsRequestObject();
+            request.PaymentRef = paymentRef;
+
+            //act, assert
+            _validator.ShouldHaveValidationErrorFor(req => req.PaymentRef, request).WithErrorMessage(ErrorMessagesFormatter.FieldIsWhiteSpaceOrEmpty("Payment reference"));
+        }
+
+        [TestCase("")]
+        [TestCase(" ")]
+        public void given_a_request_with_empty_or_whitespace_PostCode_when_GetTenancyTransactionsValidator_is_called_then_it_returns_an_error(string postCode)
+        {
+            //arrange
+            var request = TransactionHelper.CreateGetAllTenancyTransactionsRequestObject();
+            request.PostCode = postCode;
+
+            //act, assert
+            _validator.ShouldHaveValidationErrorFor(req => req.PostCode, request).WithErrorMessage(ErrorMessagesFormatter.FieldIsWhiteSpaceOrEmpty("Postcode"));
+        }
+
+        #endregion
+
+        #region Postcode format validation
+
+        // Below explanations all use the postcodes IG11 7QD and E5 3XW 
+        //"Incode" refers to the whole second part of the postcode (i.e. 3XW, 7QD) from (E11 3XW, W3 7QD)
+        //"Outcode" refers to the whole first part of the postcode (Letter(s) and number(s) - i.e. IG11, E5) from (IG11 9LL, E5 2LL)
+        //"Area" refers to the first letter(s) of the postcode (i.e.  IG, E) from (IG11 9LL, E5 2LL)
+        //"District" refers to first number(s) to appear in the postcode (i.e. 11, 5) from (IG11 9LL, E5 2LL)
+        //"Sector" refers to the number in the second part of the postcode (i.e. 9, 7) from (SW2 9DN, NE4 7JU)
+        //"Unit" refers to the letters in the second part of the postcode (i.e. DN, JU) from (SW2 9DN, NE4 7JU)
+
+        [TestCase("CR1 3ED")]
+        [TestCase("NE7")]
+        public void GivenAPostCodeValueInUpperCase_WhenCallingValidation_ItReturnsNoErrors(string postCode)
+        {
+            var request = TransactionHelper.CreateGetAllTenancyTransactionsRequestObject();
+            request.PostCode = postCode;
+            _validator.ShouldNotHaveValidationErrorFor(x => x.PostCode, request);
+        }
+
+        [TestCase("w2 5jq")]
+        [TestCase("ne7")]
+        public void GivenAPostCodeValueInLowerCase_WhenCallingValidation_ItReturnsNoErrors(string postCode)
+        {
+            var request = TransactionHelper.CreateGetAllTenancyTransactionsRequestObject();
+            request.PostCode = postCode;
+            _validator.ShouldNotHaveValidationErrorFor(x => x.PostCode, request);
+        }
+
+        [TestCase("w2 5JQ")]
+        [TestCase("E11 5ra")]
+        public void GivenAPostCodeValueInLowerCaseAndUpperCase_WhenCallingValidation_ItReturnsNoErrors(string postCode)
+        {
+            var request = TransactionHelper.CreateGetAllTenancyTransactionsRequestObject();
+            request.PostCode = postCode;
+            _validator.ShouldNotHaveValidationErrorFor(x => x.PostCode, request);
+        }
+
+        [TestCase("w2 ")]
+        [TestCase("E11 ")]
+        public void GivenAnOutcodeWithSpace_WhenCallingValidation_ItReturnsNoErrors(string postCode)
+        {
+            var request = TransactionHelper.CreateGetAllTenancyTransactionsRequestObject();
+            request.PostCode = postCode;
+            _validator.ShouldNotHaveValidationErrorFor(x => x.PostCode, request);
+        }
+
+        [TestCase("CR13ED")]
+        [TestCase("RE15AD")]
+        public void GivenPostCodeValueWithoutSpaces_WhenCallingValidation_ItReturnsNoErrors(string postCode)
+        {
+            var request = TransactionHelper.CreateGetAllTenancyTransactionsRequestObject();
+            request.PostCode = postCode;
+            _validator.ShouldNotHaveValidationErrorFor(x => x.PostCode, request);
+        }
+
+        [TestCase("NW")]
+        [TestCase("E")]
+        public void GivenOnlyAnAreaPartOfThePostCode_WhenCallingValidation_ItReturnsAnError(string postCode)
+        {
+            var request = TransactionHelper.CreateGetAllTenancyTransactionsRequestObject();
+            request.PostCode = postCode;
+            _validator.ShouldHaveValidationErrorFor(x => x.PostCode, request).WithErrorMessage(ErrorMessagesFormatter.FieldWithIncorrectFormat("postcode"));
+        }
+
+        [TestCase("17 9LL")]
+        [TestCase("8 1LA")]
+        public void GivenOnlyAnIncodeAndADistrictPartsOfThePostCode_WhenCallingValidation_ItReturnsAnError(string postCode)
+        {
+            var request = TransactionHelper.CreateGetAllTenancyTransactionsRequestObject();
+            request.PostCode = postCode;
+            _validator.ShouldHaveValidationErrorFor(x => x.PostCode, request).WithErrorMessage(ErrorMessagesFormatter.FieldWithIncorrectFormat("postcode"));
+        }
+
+        [TestCase("NW 9LL")]
+        [TestCase("NR1LW")]
+        public void GivenOnlyAnIncodeAndAnAreaPartsOfThePostCode_WhenCallingValidation_ItReturnsAnError(string postCode)
+        {
+            var request = TransactionHelper.CreateGetAllTenancyTransactionsRequestObject();
+            request.PostCode = postCode;
+            _validator.ShouldHaveValidationErrorFor(x => x.PostCode, request).WithErrorMessage(ErrorMessagesFormatter.FieldWithIncorrectFormat("postcode"));
+        }
+
+        [TestCase("1LL")]
+        [TestCase(" 6BQ")]
+        public void GivenOnlyAnIncodePartOfThePostCode_WhenCallingValidation_ItReturnsAnError(string postCode)
+        {
+            var request = TransactionHelper.CreateGetAllTenancyTransactionsRequestObject();
+            request.PostCode = postCode;
+            _validator.ShouldHaveValidationErrorFor(x => x.PostCode, request).WithErrorMessage(ErrorMessagesFormatter.FieldWithIncorrectFormat("postcode"));
+        }
+
+        [TestCase("E9")] //A9
+        [TestCase("S5")]
+        [TestCase("S11")] //A99
+        [TestCase("W12")]
+        [TestCase("NW9")] //AA9
+        [TestCase("RH5")]
+        [TestCase("SW17")] // AA99
+        [TestCase("NE17")]
+        [TestCase("W4R")] // A9A
+        [TestCase("N1C")]
+        [TestCase("NW1W")] // AA9A
+        [TestCase("CR1H")]
+        public void GivenOnlyAnOutcodePartOfPostCode_WhenCallingValidation_ItReturnsNoErrors(string postCode)
+        {
+            var request = TransactionHelper.CreateGetAllTenancyTransactionsRequestObject();
+            request.PostCode = postCode;
+            _validator.ShouldNotHaveValidationErrorFor(x => x.PostCode, request);
+        }
+
+        [TestCase("E8 1LL")]
+        [TestCase("SW17 1JK")]
+        public void GivenBothPartsOfPostCode_WhenCallingValidation_ItReturnsNoErrors(string postCode)
+        {
+            var request = TransactionHelper.CreateGetAllTenancyTransactionsRequestObject();
+            request.PostCode = postCode;
+            _validator.ShouldNotHaveValidationErrorFor(x => x.PostCode, request);
+        }
+
+        [TestCase("IG117QDfdsfdsfd")]
+        [TestCase("E1llolol")]
+        public void GivenAValidPostcodeFolowedByRandomCharacters_WhenCallingValidation_ItReturnsAnError(string postCode)
+        {
+            var request = TransactionHelper.CreateGetAllTenancyTransactionsRequestObject();
+            request.PostCode = postCode;
+            _validator.ShouldHaveValidationErrorFor(x => x.PostCode, request).WithErrorMessage(ErrorMessagesFormatter.FieldWithIncorrectFormat("postcode"));
+        }
+
+        [TestCase("EEE")]
+        [TestCase("THE")]
+        public void GivenThreeCharacters_WhenCallingValidation_ItReturnsAnError(string postCode)
+        {
+            var request = TransactionHelper.CreateGetAllTenancyTransactionsRequestObject();
+            request.PostCode = postCode;
+            _validator.ShouldHaveValidationErrorFor(x => x.PostCode, request).WithErrorMessage(ErrorMessagesFormatter.FieldWithIncorrectFormat("postcode"));
+        }
+
+        [TestCase("SW11 9")]
+        [TestCase("e14 2")]
+        public void GivenAnOutcodeAndASector_WhenCallingValidation_ItReturnsNoErrors(string postCode)
+        {
+            var request = TransactionHelper.CreateGetAllTenancyTransactionsRequestObject();
+            request.PostCode = postCode;
+            _validator.ShouldNotHaveValidationErrorFor(x => x.PostCode, request);
+        }
+
+        [TestCase("SW7 9A")]
+        [TestCase("n12 8F")]
+        public void GivenAnOutcodeAndASectorAndTheFirstLetterOfTheUnit_WhenCallingValidation_ItReturnsNoErrors(string postCode)
+        {
+            var request = TransactionHelper.CreateGetAllTenancyTransactionsRequestObject();
+            request.PostCode = postCode;
+            _validator.ShouldNotHaveValidationErrorFor(x => x.PostCode, request);
+        }
+
+        [TestCase("N8 LL")]
+        [TestCase("NW11 AE")]
+        public void GivenAnOutcodeAndAUnit_WhenCallingValidation_ItReturnsAnError(string postCode)
+        {
+            var request = TransactionHelper.CreateGetAllTenancyTransactionsRequestObject();
+            request.PostCode = postCode;
+            _validator.ShouldHaveValidationErrorFor(x => x.PostCode, request).WithErrorMessage(ErrorMessagesFormatter.FieldWithIncorrectFormat("postcode"));
+        }
+
+        [TestCase("S10 H")]
+        [TestCase("W1 J")]
+        public void GivenAnOutcodeAndOnlyOneLetterOfAUnit_WhenCallingValidation_ItReturnsAnError(string postCode)
+        {
+            var request = TransactionHelper.CreateGetAllTenancyTransactionsRequestObject();
+            request.PostCode = postCode;
+            _validator.ShouldHaveValidationErrorFor(x => x.PostCode, request).WithErrorMessage(ErrorMessagesFormatter.FieldWithIncorrectFormat("postcode"));
+        }
+
+        #endregion
+
+        #region format is valid tests
+
+        [Test]
+        public void given_a_request_with_valid_PaymentRef_when_GetTenancyTransactionsValidator_is_called_then_it_returns_no_error()
+        {
+            //arange
+            var request = TransactionHelper.CreateGetAllTenancyTransactionsRequestObject();
+
+            //act, assert
+            _validator.ShouldNotHaveValidationErrorFor(req => req.PaymentRef, request);
+        }
+
+        [Test]
+        public void given_a_request_with_valid_PostCode_guid_when_GetTenancyTransactionsValidator_is_called_then_it_returns_no_error() //if this ever fails, it's probably because faker isn't generating correct code
+        {
+            //arange
+            var request = TransactionHelper.CreateGetAllTenancyTransactionsRequestObject();
+
+            //act, assert
+            _validator.ShouldNotHaveValidationErrorFor(req => req.PostCode, request);
+        }
+
+        #endregion
+
+    }
+}

--- a/transactions-api.Tests/V1/Validation/GetTenancyTransactionsValidatorTests.cs
+++ b/transactions-api.Tests/V1/Validation/GetTenancyTransactionsValidatorTests.cs
@@ -264,7 +264,7 @@ namespace transactions_api.Tests.V1.Validation
         }
 
         [Test]
-        public void given_a_request_with_valid_PostCode_guid_when_GetTenancyTransactionsValidator_is_called_then_it_returns_no_error() //if this ever fails, it's probably because faker isn't generating correct code
+        public void given_a_request_with_valid_PostCode_when_GetTenancyTransactionsValidator_is_called_then_it_returns_no_error() //if this ever fails, it's probably because faker isn't generating correct code
         {
             //arange
             var request = TransactionHelper.CreateGetAllTenancyTransactionsRequestObject();

--- a/transactions-api/Startup.cs
+++ b/transactions-api/Startup.cs
@@ -18,6 +18,8 @@ using Microsoft.AspNetCore.Mvc.Versioning;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using transactions_api.Versioning;
 using UnitTests.V1.Infrastructure;
+using FluentValidation.AspNetCore;
+using transactions_api.V1.Validation;
 
 namespace transactions_api
 {
@@ -34,7 +36,7 @@ namespace transactions_api
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
+            services.AddMvc().AddFluentValidation().SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
             services.AddApiVersioning(o =>
             {
                 o.DefaultApiVersion = new ApiVersion(1, 0);
@@ -94,6 +96,7 @@ namespace transactions_api
             ConfigureDbContext(services);
             RegisterGateWays(services);
             RegisterUseCases(services);
+            RegisterValidators(services);
             services.AddMvcCore().AddDataAnnotations();
         }
 
@@ -115,6 +118,11 @@ namespace transactions_api
         private static void RegisterUseCases(IServiceCollection services)
         {
             services.AddSingleton<IListTransactions, ListTransactionsUsecase>();
+        }
+
+        private static void RegisterValidators(IServiceCollection services)
+        {
+            services.AddTransient<IGetTenancyTransactionsValidator, GetTenancyTransactionsValidator>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/transactions-api/V1/Boundary/GetAllTenancyTransactionsRequest.cs
+++ b/transactions-api/V1/Boundary/GetAllTenancyTransactionsRequest.cs
@@ -1,0 +1,14 @@
+using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace transactions_api.V1.Boundary
+{
+    public class GetAllTenancyTransactionsRequest
+    {
+        [FromRoute(Name = "payment_ref")]   public string PaymentRef { get; set; }
+        [FromRoute(Name = "post_code")]     public string PostCode { get; set; }
+    }
+}

--- a/transactions-api/V1/Boundary/GetAllTenancyTransactionsResponse.cs
+++ b/transactions-api/V1/Boundary/GetAllTenancyTransactionsResponse.cs
@@ -11,6 +11,6 @@ namespace transactions_api.V1.Boundary
         public DateTime GeneratedAt { get; set; }
         public GetAllTenancyTransactionsRequest Request { get; set; }
         public List<TenancyTransaction> Transactions { get; set; }
-        public string CurrentBalance { get; set; }
+        public TenancyAgreementDetails TenancyDetails { get; set; }
     }
 }

--- a/transactions-api/V1/Boundary/GetAllTenancyTransactionsResponse.cs
+++ b/transactions-api/V1/Boundary/GetAllTenancyTransactionsResponse.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using transactions_api.V1.Domain;
+
+namespace transactions_api.V1.Boundary
+{
+    public class GetAllTenancyTransactionsResponse
+    {
+        public DateTime GeneratedAt { get; set; }
+        public GetAllTenancyTransactionsRequest Request { get; set; }
+        public List<TenancyTransaction> Transactions { get; set; }
+        public string CurrentBalance { get; set; }
+    }
+}

--- a/transactions-api/V1/Controllers/TransactionsController.cs
+++ b/transactions-api/V1/Controllers/TransactionsController.cs
@@ -42,7 +42,9 @@ namespace transactions_api.Controllers.V1
             
             if (validationResult.IsValid)
             {
-                return Ok(new { }); // had to use anonymous object, because if no object is put inside Ok(), it will produce OkResult, not OkObjectResult, which we want down the line...
+                var usecaseResponse = _listTransactions.ExecuteGetTenancyTransactions(request);
+
+                return Ok(usecaseResponse);
             }
 
             return BadRequest(

--- a/transactions-api/V1/Controllers/TransactionsController.cs
+++ b/transactions-api/V1/Controllers/TransactionsController.cs
@@ -34,22 +34,46 @@ namespace transactions_api.Controllers.V1
         }
 
         [HttpGet]
-        [Route("payment-ref/{payment_ref}/post-code/{post_code}")] //should we add "GetAllTenancyTransactions/" to the start of the url?
+        [Route("payment-ref/{payment_ref}/post-code/{post_code}")]                                              //should we add "GetAllTenancyTransactions/" to the start of the url?
         [Produces("application/json")]
+        [ProducesResponseType(typeof(GetAllTenancyTransactionsResponse), 200)]
+        [ProducesResponseType(typeof(ErrorResponse), 400)]
+        [ProducesResponseType(typeof(ErrorResponse), 500)]
         public IActionResult GetAllTenancyTransactions([FromRoute] GetAllTenancyTransactionsRequest request)
         {
-            var validationResult = _getTenancyTransactionsValidator.Validate(request);
-            
-            if (validationResult.IsValid)
-            {
-                var usecaseResponse = _listTransactions.ExecuteGetTenancyTransactions(request);
-
-                return Ok(usecaseResponse);
-            }
-
-            return BadRequest(
-                    new ErrorResponse(validationResult.Errors)
+            _logger.LogInformation(                                                                             //TODO: Add tests for logging! An the rest of the logging. Add logging message formatter.
+                $"The request has hit GetAllTenancyTransactions controller with the following data. PaymentRef = {request.PaymentRef ?? "null" } and PostCode = {request.PostCode ?? "null"}"
                 );
+
+            try                                                                                                 //TODO: add tests for this. No tests due to this needing to be rushed!
+            {
+                var validationResult = _getTenancyTransactionsValidator.Validate(request);
+
+                if (validationResult.IsValid)
+                {
+                    var usecaseResponse = _listTransactions.ExecuteGetTenancyTransactions(request);
+
+                    return Ok(usecaseResponse);
+                }
+
+                return BadRequest(
+                    new ErrorResponse(validationResult.Errors)
+                    );
+            }
+            catch (AggregateException ex) when ( ex.InnerException != null )
+            {
+                return StatusCode(
+                    500,
+                    new ErrorResponse(ex.Message, ex.InnerException.Message)
+                    );
+            }
+            catch (Exception ex)
+            {
+                return StatusCode(
+                    500,
+                    new ErrorResponse(ex.Message)
+                    );
+            }
         }
     }
 }

--- a/transactions-api/V1/Controllers/TransactionsController.cs
+++ b/transactions-api/V1/Controllers/TransactionsController.cs
@@ -28,5 +28,13 @@ namespace transactions_api.Controllers.V1
             var usecaseResponce = _listTransactions.Execute(request);
             return new JsonResult(usecaseResponce) {StatusCode = 200};
         }
+
+        [HttpGet]
+        [Route("payment-ref/{payment_ref}/post-code/{post_code}")] //should we add "GetAllTenancyTransactions/" to the start of the url?
+        [Produces("application/json")]
+        public IActionResult GetAllTenancyTransactions([FromRoute] GetAllTenancyTransactionsRequest request)
+        {
+            return Ok(new { }); // had to use anonymous object, because if no object is put inside Ok(), it will produce OkResult, not OkObjectResult, which we want down the line...
+        }
     }
 }

--- a/transactions-api/V1/Domain/TenancyTransaction.cs
+++ b/transactions-api/V1/Domain/TenancyTransaction.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace transactions_api.V1.Domain
+{
+    public class TenancyTransaction
+    {
+        public string Date { get; set; }
+        public string Amount { get; set; }
+        public string Type { get; set; }
+        public string Description { get; set; }
+    }
+}

--- a/transactions-api/V1/Domain/TenancyTransaction.cs
+++ b/transactions-api/V1/Domain/TenancyTransaction.cs
@@ -22,12 +22,17 @@ namespace transactions_api.V1.Domain                            //This is where 
         public string Description { get; set; }
     }
 
-    public class TenancyAgreementDetails                        //Added this here as it's interconnected with the rest of the code
+    public class TenancyAgreementDetails
     {
         public string CurrentBalance { get; set; }
-        public string DisplayBalance { get; set; }              //Leaving this in as they want "the data that comes from NCC".
-        public string PropertyReferenceNumber { get; set; }     //Leaving this in as they want "the data that comes from NCC".
+        public string DisplayBalance { get; set; }
+        public string Rent { get; set; }
+        public string StartDate {get; set; }
+        public string HousingReferenceNumber { get; set; }
+        public string PropertyReferenceNumber { get; set; }
+        public string TenancyAgreementReference { get; set; }     //Need this for the main query to work as usual.
         public string PaymentReferenceNumber { get; set; }
-        public string TenureType { get; set; } 
+        public bool IsAgreementTerminated { get; set; }
+        public string TenureType { get; set; }
     }
 }

--- a/transactions-api/V1/Domain/TenancyTransaction.cs
+++ b/transactions-api/V1/Domain/TenancyTransaction.cs
@@ -3,9 +3,18 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
-namespace transactions_api.V1.Domain
+namespace transactions_api.V1.Domain                    //This is where the "porting from NCC" starts
 {
-    public class TenancyTransaction
+    public class TenancyTransaction                     //'In' and 'Out' - don't think it makes sense to have it like this long term. I think it's Front-End's responsibility to distinguish between positive and negative amounts.
+    {
+        public string Date { get; set; }
+        public string Description { get; set; }
+        public string In { get; set; }
+        public string Out { get; set; }
+        public string Balance { get; set; }
+    }
+
+    public class TempTenancyTransaction                 //Temporary class from NCC so that the data from sql query would get automapped. But I think this should be our return object with an addition of balance.
     {
         public string Date { get; set; }
         public string Amount { get; set; }

--- a/transactions-api/V1/Domain/TenancyTransaction.cs
+++ b/transactions-api/V1/Domain/TenancyTransaction.cs
@@ -3,9 +3,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
-namespace transactions_api.V1.Domain                    //This is where the "porting from NCC" starts
+namespace transactions_api.V1.Domain                            //This is where the "porting from NCC" starts
 {
-    public class TenancyTransaction                     //'In' and 'Out' - don't think it makes sense to have it like this long term. I think it's Front-End's responsibility to distinguish between positive and negative amounts.
+    public class TenancyTransaction                             //'In' and 'Out' - don't think it makes sense to have it like this long term. I think it's Front-End's responsibility to distinguish between positive and negative amounts.
     {
         public string Date { get; set; }
         public string Description { get; set; }
@@ -14,11 +14,20 @@ namespace transactions_api.V1.Domain                    //This is where the "por
         public string Balance { get; set; }
     }
 
-    public class TempTenancyTransaction                 //Temporary class from NCC so that the data from sql query would get automapped. But I think this should be our return object with an addition of balance.
+    public class TempTenancyTransaction                         //Temporary class from NCC so that the data from sql query would get automapped. But I think this should be our return object with an addition of balance.
     {
         public string Date { get; set; }
         public string Amount { get; set; }
         public string Type { get; set; }
         public string Description { get; set; }
+    }
+
+    public class TenancyAgreementDetails                        //Added this here as it's interconnected with the rest of the code
+    {
+        public string CurrentBalance { get; set; }
+        public string DisplayBalance { get; set; }              //Leaving this in as they want "the data that comes from NCC".
+        public string PropertyReferenceNumber { get; set; }     //Leaving this in as they want "the data that comes from NCC".
+        public string PaymentReferenceNumber { get; set; }
+        public string TenureType { get; set; } 
     }
 }

--- a/transactions-api/V1/Exceptions/ErrorResponse.cs
+++ b/transactions-api/V1/Exceptions/ErrorResponse.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentValidation.Results;
+using transactions_api.V1.Helpers;
+using FV = FluentValidation.Results;
+
+namespace transactions_api.V1.Exceptions
+{
+    /// <summary>
+    /// This is an Error Object that conforms to Hackney's API Playbook standards:
+    ///
+    ///     {
+    ///        "status" : "fail",
+    ///        "errors" : [ "A title is required" ]
+    ///     }
+    ///
+    /// Defined at: "https://github.com/LBHackney-IT/API-Playbook-v2-beta/blob/master/api-guidelines/data-formats.md"
+    /// </summary>
+
+    public class ErrorResponse
+    {
+        public string status { get; set; } = "fail";
+        public List<string> errors { get; set; }
+
+        public ErrorResponse()
+        {
+            errors = new List<string>();
+        }
+
+        public ErrorResponse(List<string> errorList)
+        {
+            errors = errorList;
+        }
+
+        public ErrorResponse(params string[] errorStrings)
+        {
+            errors = errorStrings.ToList();
+        }
+
+        public ErrorResponse(IList<ValidationFailure> validationFailures)
+        {
+            errors = ErrorMessagesFormatter.FormatValidationFailures(validationFailures);
+        }
+    }
+}

--- a/transactions-api/V1/Gateways/ITransactionsGateway.cs
+++ b/transactions-api/V1/Gateways/ITransactionsGateway.cs
@@ -6,7 +6,7 @@ namespace UnitTests.V1.Gateways
     public interface ITransactionsGateway
     {
         List<Transaction> GetTransactionsByTagRef(string propertyRef);
-        List<TenancyTransaction> GetAllTenancyTransactionStatements(string tenancyAgreementId, string paymentReferenceNumber, string postcode);
+        List<TenancyTransaction> GetAllTenancyTransactionStatements(string tenancyAgreementId, TenancyAgreementDetails tenantDet); // I know it could do away with tenanDet only, but I feel like making tenancyAgreementId an explicit requirement right now..
         TenancyAgreementDetails GetTenancyAgreementDetails(string paymentReferenceNumber, string postcode);
         List<TempTenancyTransaction> GetAllTenancyTransactions(string tenancyAgreementRef);
     }

--- a/transactions-api/V1/Gateways/ITransactionsGateway.cs
+++ b/transactions-api/V1/Gateways/ITransactionsGateway.cs
@@ -6,5 +6,8 @@ namespace UnitTests.V1.Gateways
     public interface ITransactionsGateway
     {
         List<Transaction> GetTransactionsByTagRef(string propertyRef);
+        List<TenancyTransaction> GetAllTenancyTransactionStatements(string tenancyAgreementId, string paymentReferenceNumber, string postcode);
+        TenancyAgreementDetails GetTenancyAgreementDetails(string paymentReferenceNumber, string postcode);
+        List<TempTenancyTransaction> GetAllTenancyTransactions(string tenancyAgreementRef);
     }
 }

--- a/transactions-api/V1/Gateways/TransactionsGateway.cs
+++ b/transactions-api/V1/Gateways/TransactionsGateway.cs
@@ -147,9 +147,8 @@ namespace UnitTests.V1.Gateways
 
         }
 
-        public List<TenancyTransaction> GetAllTenancyTransactionStatements(string tenancyAgreementId, string paymentReferenceNumber, string postcode)
+        public List<TenancyTransaction> GetAllTenancyTransactionStatements(string tenancyAgreementId, TenancyAgreementDetails tenantDet)
         {
-            TenancyAgreementDetails tenantDet = GetTenancyAgreementDetails(paymentReferenceNumber, postcode);
             List<TempTenancyTransaction> lstTransactions = GetAllTenancyTransactions(tenancyAgreementId);
             List<TenancyTransaction> lstTransactionsState = new List<TenancyTransaction>();
             float RecordBalance = 0;

--- a/transactions-api/V1/Gateways/TransactionsGateway.cs
+++ b/transactions-api/V1/Gateways/TransactionsGateway.cs
@@ -64,6 +64,10 @@ namespace UnitTests.V1.Gateways
         {
             SqlConnection uhtconn = new SqlConnection(_uhliveTransconnstring);
             uhtconn.Open();
+            var dbArgs = new DynamicParameters();
+
+            dbArgs.Add("@tenancyAgreementRef", tenancyAgreementRef, System.Data.DbType.String);
+                //dbArgs.Add("@postcode", request.PostCode.Replace(" ", "") + "%", DbType.AnsiString); ;
 
             string query =                                                                                      // not sure how to limit 2 different queries to 5 results (UNION). OFFSET won't work.
                 @" 
@@ -108,7 +112,7 @@ namespace UnitTests.V1.Gateways
                     ORDER  BY post_date DESC, 
                               transno ASC
                 ";
-            var results = uhtconn.Query<TempTenancyTransaction>(query, new { tenancyAgreementRef }, commandTimeout: 0).ToList();  //<--------Can do .Take(5).ToList(); also commandTimeout: 0 is a hack to get around timeout that comes out of nowhere - query runs fine on SQL management studio
+            var results = uhtconn.Query<TempTenancyTransaction>(query, new { @tenancyAgreementRef = new DbString { Value = tenancyAgreementRef, IsFixedLength = true, IsAnsi = true, Length = 11 } }).ToList();  //<--------Can do .Take(5).ToList(); also commandTimeout: 0 is a hack to get around timeout that comes out of nowhere - query runs fine on SQL management studio
             uhtconn.Close();
             return results;
         }

--- a/transactions-api/V1/Gateways/TransactionsGateway.cs
+++ b/transactions-api/V1/Gateways/TransactionsGateway.cs
@@ -22,6 +22,8 @@ namespace UnitTests.V1.Gateways
             _uhcontext = uhcontext;
         }
 
+        #region GetTransactions (in general)
+
         public List<Transaction> GetTransactionsByTagRef(string tagRef)
         {
             var result = (from rtrans in _uhcontext.UTransactions
@@ -48,5 +50,144 @@ namespace UnitTests.V1.Gateways
 
             return result;
         }
+
+        #endregion
+
+        #region GetTenancyTransactions
+
+        //---------------------------------- Ported Code from NCC API (start) --------------------------------//
+
+        public List<TenancyTransactions> GetAllTenancyTransactions(string tenancyAgreementRef, string startdate, string endDate)
+        {
+            SqlConnection uhtconn = new SqlConnection(_uhliveTransconnstring);
+            uhtconn.Open();
+
+            string fstartDate = Utils.FormatDate(startdate);
+            string fendDate = (!string.IsNullOrEmpty(endDate)) ? Utils.FormatDate(endDate) : DateTime.Now.ToString("yyyy-MM-dd");
+            string query =
+                @" 
+                    SELECT transno, 
+                           rtrans.real_value AS Amount, 
+                           rtrans.post_date  AS date, 
+                           rtrans.trans_type AS Type, 
+                           CASE 
+                             WHEN rtrans.trans_type = 'DSB' THEN RTRIM(debtype.deb_desc) 
+                             ELSE RTRIM(rectype.rec_desc) 
+                           END               AS Description 
+                    FROM   rtrans 
+                           LEFT JOIN rectype 
+                                  ON rtrans.trans_type = rectype.rec_code 
+                           LEFT JOIN debtype 
+                                  ON rtrans.trans_type = debtype.deb_code 
+                    WHERE  tag_ref <> '' 
+                           AND tag_ref <> 'ZZZZZZ' 
+                           AND post_date BETWEEN @fstartDate AND @fendDate 
+                           AND tag_ref = @tenancyAgreementRef 
+                           AND ( trans_type IN (SELECT rec_code 
+                                                FROM   rectype 
+                                                WHERE  rec_group <= 8 
+                                                        OR rec_code = 'RIT') 
+                                  OR trans_type = 'DSB' ) 
+                    UNION ALL 
+                    SELECT 999999999999999999     AS transno, 
+                           SUM(rtrans.real_value) AS Amount, 
+                           post_date              AS Date, 
+                           'RNT'                  AS Type, 
+                           'Total Charge'         AS Description 
+                    FROM   rtrans 
+                    WHERE  tag_ref <> '' 
+                           AND tag_ref <> 'ZZZZZZ' 
+                           AND tag_ref = @tenancyAgreementRef 
+                           AND post_date BETWEEN @fstartDate AND @fendDate 
+                           AND rtrans.trans_type LIKE 'D%' 
+                           AND rtrans.trans_type <> 'DSB' 
+                           AND post_date = post_date 
+                    GROUP  BY tag_ref, 
+                              post_date, 
+                              prop_ref, 
+                              house_ref 
+                    ORDER  BY post_date DESC, 
+                              transno ASC 
+                ";
+            var results = uhtconn.Query<TenancyTransactions>(query, new { tenancyAgreementRef, fstartDate, fendDate }).ToList();
+            uhtconn.Close();
+            return results;
+        }
+
+        public TenancyAgreementDetials GetTenancyAgreementDetails(string tenancyAgreementRef)
+        {
+            SqlConnection uhtconn = new SqlConnection(_uhliveTransconnstring);
+            uhtconn.Open();
+
+            var result = uhtconn.QueryFirstOrDefault<TenancyAgreementDetials>(
+                @"
+                    SELECT cur_bal                           AS CurrentBalance, 
+                           ( cur_bal *- 1 )                  AS DisplayBalance, 
+                           ( rent + service + other_charge ) AS Rent, 
+                           cot                               AS StartDate, 
+                           RTRIM(house_ref)                  AS HousingReferenceNumber, 
+                           RTRIM(prop_ref)                   AS PropertyReferenceNumber, 
+                           RTRIM(u_saff_rentacc)             AS PaymentReferenceNumber, 
+                           terminated                        AS IsAgreementTerminated, 
+                           tenure                            AS TenureType 
+                    FROM   tenagree 
+                    WHERE  tag_ref = @tenancyAgreementRef 
+                ",
+                new { tenancyAgreementRef }
+            );
+
+            uhtconn.Close();
+
+            return result;
+
+        }
+
+        public List<TenancyTransactionStatements> GetAllTenancyTransactionStatements(string tenancyAgreementId, string startdate, string endDate)
+        {
+            TenancyAgreementDetials tenantDet = GetTenancyAgreementDetails(tenancyAgreementId);
+            List<TenancyTransactions> lstTransactions = GetAllTenancyTransactions(tenancyAgreementId, startdate, endDate);
+            List<TenancyTransactionStatements> lstTransactionsState = new List<TenancyTransactionStatements>();
+            float RecordBalance = 0;
+            RecordBalance = float.Parse(tenantDet.CurrentBalance);
+
+            foreach (TenancyTransactions trans in lstTransactions)
+            {
+                TenancyTransactionStatements statement = new TenancyTransactionStatements();
+                var DebitValue = "";
+                var CreditValue = "";
+                float fDebitValue = 0F;
+                float fCreditValue = 0F;
+                var realvalue = trans.Amount;
+                string DisplayRecordBalance = (-RecordBalance).ToString("c2");
+
+                if (realvalue.IndexOf("-") != -1)
+                {
+                    DebitValue = realvalue;
+                    fDebitValue = float.Parse(DebitValue);
+                    RecordBalance = (RecordBalance - fDebitValue);
+                    DebitValue = (-fDebitValue).ToString("c2");
+                }
+                else
+                {
+                    CreditValue = realvalue;
+                    fCreditValue = float.Parse(CreditValue);
+                    RecordBalance = (RecordBalance - fCreditValue);
+                    CreditValue = (-fCreditValue).ToString("c2");
+                }
+                statement.Date = trans.Date;
+                statement.Description = trans.Description;
+                statement.In = DebitValue;
+                statement.Out = CreditValue;
+                statement.Balance = DisplayRecordBalance;
+                lstTransactionsState.Add(statement);
+            }
+
+            return lstTransactionsState;
+
+        }
+
+        //---------------------------------- Ported Code from NCC API (end) --------------------------------//
+
+        #endregion
     }
 }

--- a/transactions-api/V1/Helpers/ErrorMessagesFormatter.cs
+++ b/transactions-api/V1/Helpers/ErrorMessagesFormatter.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentValidation.Results;
+using FV = FluentValidation.Results;
+
+namespace transactions_api.V1.Helpers
+{
+    /// <summary>
+    /// The idea behind this is having a centralized place to store error message formats.
+    /// 
+    /// Issue is that whenever there is a change to the error message or the way it's phrased, you have to go
+    /// about changing it at different places in code where it appears - not only in implementation from endpoint to endpoint,
+    /// but tests as well.
+    /// 
+    /// Rather than doing that, I think it's for the best to have a helper method for the error messages, and then
+    /// if there's a need for a change something, you do it here in one spot. This also has the benefit of improved consistency.
+    /// </summary>
+
+    public static class ErrorMessagesFormatter
+    {
+        public static List<string> FormatValidationFailures(IList<ValidationFailure> validationFailures)
+        {
+            return validationFailures.Aggregate(
+                            new List<string>(),
+                            (errorList, validationFailure) =>
+                            {
+                                errorList.Add(FluentValidationsFailureMessage(validationFailure.PropertyName, validationFailure.ErrorMessage));
+                                return errorList;
+                            }
+                        );
+        }
+
+        public static string FluentValidationsFailureMessage(string propertyName, string errorMessage)
+        {
+            return $"Property {propertyName} failed validation. Error was: {errorMessage}";
+        }
+    }
+}

--- a/transactions-api/V1/Helpers/ErrorMessagesFormatter.cs
+++ b/transactions-api/V1/Helpers/ErrorMessagesFormatter.cs
@@ -36,5 +36,20 @@ namespace transactions_api.V1.Helpers
         {
             return $"Property {propertyName} failed validation. Error was: {errorMessage}";
         }
+
+        public static string FieldIsNullMessage(string fieldName)
+        {
+            return $"{fieldName} must be provided.";
+        }
+
+        public static string FieldIsWhiteSpaceOrEmpty(string fieldName)
+        {
+            return $"{fieldName} must not be empty.";
+        }
+
+        public static string FieldWithIncorrectFormat(string fieldName)
+        {
+            return $"Provided {fieldName} format is incorrect.";
+        }
     }
 }

--- a/transactions-api/V1/UseCase/IListTransactions.cs
+++ b/transactions-api/V1/UseCase/IListTransactions.cs
@@ -3,5 +3,6 @@ namespace transactions_api.V1.Boundary
     public interface IListTransactions
     {
         ListTransactionsResponse Execute(ListTransactionsRequest propertyRefrence);
+        GetAllTenancyTransactionsResponse ExecuteGetTenancyTransactions(GetAllTenancyTransactionsRequest request);
     }
 }

--- a/transactions-api/V1/UseCase/ListTransactionsUsecase.cs
+++ b/transactions-api/V1/UseCase/ListTransactionsUsecase.cs
@@ -24,5 +24,10 @@ namespace transactions_api.UseCase
 
             return new ListTransactionsResponse(results, listTransactionsRequest, DateTime.Now);
         }
+
+        public GetAllTenancyTransactionsResponse ExecuteGetTenancyTransactions(GetAllTenancyTransactionsRequest request)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/transactions-api/V1/UseCase/ListTransactionsUsecase.cs
+++ b/transactions-api/V1/UseCase/ListTransactionsUsecase.cs
@@ -27,6 +27,9 @@ namespace transactions_api.UseCase
 
         public GetAllTenancyTransactionsResponse ExecuteGetTenancyTransactions(GetAllTenancyTransactionsRequest request)
         {
+            //GetTenancyAgreementDetails(pay_ref, postcode) --> tag_ref, cur_bal
+
+            //GetAllTenancyTransactionStatements(tag_ref) --> get back a list...o TOP 5
             throw new NotImplementedException();
         }
     }

--- a/transactions-api/V1/UseCase/ListTransactionsUsecase.cs
+++ b/transactions-api/V1/UseCase/ListTransactionsUsecase.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using transactions_api.V1.Boundary;
+using transactions_api.V1.Domain;
 using transactions_api.V1.Helpers;
 using UnitTests.V1.Gateways;
 
@@ -27,10 +29,19 @@ namespace transactions_api.UseCase
 
         public GetAllTenancyTransactionsResponse ExecuteGetTenancyTransactions(GetAllTenancyTransactionsRequest request)
         {
-            //GetTenancyAgreementDetails(pay_ref, postcode) --> tag_ref, cur_bal
+            var tenancyDetails = _transactionsGateway.GetTenancyAgreementDetails(request.PaymentRef, request.PostCode) ?? new TenancyAgreementDetails();
 
-            //GetAllTenancyTransactionStatements(tag_ref) --> get back a list...o TOP 5
-            throw new NotImplementedException();
+            var transactions = !String.IsNullOrEmpty(tenancyDetails.TenancyAgreementReference)
+                               ? _transactionsGateway.GetAllTenancyTransactionStatements(tenancyDetails.TenancyAgreementReference, request.PaymentRef, request.PostCode)
+                               : new List<TenancyTransaction>();
+
+            return new GetAllTenancyTransactionsResponse()
+            {
+                GeneratedAt = DateTime.Now,
+                Request = request,
+                Transactions = transactions,
+                TenancyDetails = tenancyDetails                                                                         //This is no longer Transactions API... it's getting back Tenancy data!
+            };
         }
     }
 }

--- a/transactions-api/V1/UseCase/ListTransactionsUsecase.cs
+++ b/transactions-api/V1/UseCase/ListTransactionsUsecase.cs
@@ -32,7 +32,7 @@ namespace transactions_api.UseCase
             var tenancyDetails = _transactionsGateway.GetTenancyAgreementDetails(request.PaymentRef, request.PostCode) ?? new TenancyAgreementDetails();
 
             var transactions = !String.IsNullOrEmpty(tenancyDetails.TenancyAgreementReference)
-                               ? _transactionsGateway.GetAllTenancyTransactionStatements(tenancyDetails.TenancyAgreementReference, request.PaymentRef, request.PostCode)
+                               ? _transactionsGateway.GetAllTenancyTransactionStatements(tenancyDetails.TenancyAgreementReference, tenancyDetails)
                                : new List<TenancyTransaction>();
 
             return new GetAllTenancyTransactionsResponse()

--- a/transactions-api/V1/Validation/GetTenancyTransactionsValidator.cs
+++ b/transactions-api/V1/Validation/GetTenancyTransactionsValidator.cs
@@ -1,0 +1,27 @@
+using FluentValidation;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using transactions_api.V1.Boundary;
+using transactions_api.V1.Helpers;
+
+namespace transactions_api.V1.Validation
+{
+    public class GetTenancyTransactionsValidator : AbstractValidator<GetAllTenancyTransactionsRequest>, IGetTenancyTransactionsValidator
+    {
+        public GetTenancyTransactionsValidator()
+        {
+            RuleFor(request => request.PaymentRef)
+                .NotNull().WithMessage(ErrorMessagesFormatter.FieldIsNullMessage("Payment reference"))
+                .NotEmpty().WithMessage(ErrorMessagesFormatter.FieldIsWhiteSpaceOrEmpty("Payment reference"));
+
+            RuleFor(request => request.PostCode)
+                .NotNull().WithMessage(ErrorMessagesFormatter.FieldIsNullMessage("Postcode"))
+                .NotEmpty().WithMessage(ErrorMessagesFormatter.FieldIsWhiteSpaceOrEmpty("Postcode"))
+                .Matches(new Regex("^((([A-Za-z][0-9]{1,2})|(([A-Za-z][A-Ha-hJ-Yj-y][0-9]{1,2})|(([A-Za-z][0-9][A-Za-z])|([A-Za-z][A-Ha-hJ-Yj-y][0-9][A-Za-z]))))( )?(([0-9][A-Za-z]?[A-Za-z]?)?))$"))
+                .WithMessage(ErrorMessagesFormatter.FieldWithIncorrectFormat("postcode"));
+        }
+    }
+}

--- a/transactions-api/V1/Validation/GetTenancyTransactionsValidator.cs
+++ b/transactions-api/V1/Validation/GetTenancyTransactionsValidator.cs
@@ -13,6 +13,7 @@ namespace transactions_api.V1.Validation
     {
         public GetTenancyTransactionsValidator()
         {
+            ValidatorOptions.Global.CascadeMode = CascadeMode.StopOnFirstFailure;
             RuleFor(request => request.PaymentRef)
                 .NotNull().WithMessage(ErrorMessagesFormatter.FieldIsNullMessage("Payment reference"))
                 .NotEmpty().WithMessage(ErrorMessagesFormatter.FieldIsWhiteSpaceOrEmpty("Payment reference"));

--- a/transactions-api/V1/Validation/IGetTenancyTransactionsValidator.cs
+++ b/transactions-api/V1/Validation/IGetTenancyTransactionsValidator.cs
@@ -1,0 +1,14 @@
+using FluentValidation.Results;
+using transactions_api.V1.Boundary;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace transactions_api.V1.Validation
+{
+    public interface IGetTenancyTransactionsValidator
+    {
+        ValidationResult Validate(GetAllTenancyTransactionsRequest request);
+    }
+}

--- a/transactions-api/transactions-api.csproj
+++ b/transactions-api/transactions-api.csproj
@@ -13,8 +13,10 @@
     <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Dapper" Version="2.0.35" />
     <PackageReference Include="FluentValidation" Version="9.0.0-preview3" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="9.0.0-preview3" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.17" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.HealthChecks" Version="1.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="2.1.0" />

--- a/transactions-api/transactions-api.csproj
+++ b/transactions-api/transactions-api.csproj
@@ -13,6 +13,8 @@
     <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="FluentValidation" Version="9.0.0-preview3" />
+    <PackageReference Include="FluentValidation.AspNetCore" Version="9.0.0-preview3" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.HealthChecks" Version="1.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="2.1.0" />


### PR DESCRIPTION
# What:
- A rushed port of [NCC API](https://github.com/LBHackney-IT/LBHNCCApi) "get all tenancy transactions" endpoint [code](https://github.com/LBHackney-IT/LBHNCCApi/blob/master/LbhNCCApi/Actions/UHActions.cs#L180-L274). With a sprinkle of some standards on top of it, where they could be introduced.

# Why:
- There was a need for an API to be on AWS that would give the transactions data (required by "AWS Connect" project). Trying to stray away from NCC API, the functionality had to be put into transactions api.
- The code was ported (rather than rewritten) due to extreemely short deadline (no time for planning) to deliver a working product (with an idea of redoing it some time in the future properly).
- Ported parts of the code (and logging) were not tested due to the fact that it is going to change for not following our standards, when this code gets revisited.

# Notes:
- The response object does not make sense for a "transactions api" as it's violating the idea of it being a microservice (it's returning tenancy details). Hence, the response is likely to change in the future!