### PR TITLE
Fix - Separate out tenancy details from transactions

### DIFF
--- a/transactions-api.Tests/V1/Controllers/TransactionsControllerTests.cs
+++ b/transactions-api.Tests/V1/Controllers/TransactionsControllerTests.cs
@@ -26,6 +26,7 @@ namespace UnitTests.V1.Controllers
 
         private Mock<IListTransactions> _mockListTransacionsUsecase;
         private Mock<IGetTenancyTransactionsValidator> _mockGetTenancyTransactionsValidator;
+        private Mock<IGetTenancyDetailsValidator> _mockGetTenancyDetailsValidator;
 
         private Faker _faker = new Faker("en_GB");
 
@@ -34,8 +35,9 @@ namespace UnitTests.V1.Controllers
         {
             _mockListTransacionsUsecase = new Mock<IListTransactions>();
             _mockGetTenancyTransactionsValidator = new Mock<IGetTenancyTransactionsValidator>();
+            _mockGetTenancyDetailsValidator = new Mock<IGetTenancyDetailsValidator>();
             ILogger<TransactionsController> nullLogger = NullLogger<TransactionsController>.Instance;
-            _classUnderTest = new TransactionsController(_mockListTransacionsUsecase.Object, nullLogger, _mockGetTenancyTransactionsValidator.Object);
+            _classUnderTest = new TransactionsController(_mockListTransacionsUsecase.Object, nullLogger, _mockGetTenancyTransactionsValidator.Object, _mockGetTenancyDetailsValidator.Object);
         }
 
         #region Transactions in General

--- a/transactions-api.Tests/V1/Helper/TransactionHelper.cs
+++ b/transactions-api.Tests/V1/Helper/TransactionHelper.cs
@@ -102,8 +102,7 @@ namespace UnitTests.V1.Helper
             {
                 GeneratedAt = DateTime.Now,
                 Request = CreateGetAllTenancyTransactionsRequestObject(),
-                Transactions = CreateTenancyTransactionList(5),
-                TenancyDetails = CreateTenancyAgreementDetails()
+                Transactions = CreateTenancyTransactionList(5)
             };
         }
 

--- a/transactions-api/Startup.cs
+++ b/transactions-api/Startup.cs
@@ -123,6 +123,7 @@ namespace transactions_api
         private static void RegisterValidators(IServiceCollection services)
         {
             services.AddTransient<IGetTenancyTransactionsValidator, GetTenancyTransactionsValidator>();
+            services.AddTransient<IGetTenancyDetailsValidator, GetTenancyDetailsValidator>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/transactions-api/V1/Boundary/GetAllTenancyTransactionsResponse.cs
+++ b/transactions-api/V1/Boundary/GetAllTenancyTransactionsResponse.cs
@@ -11,6 +11,5 @@ namespace transactions_api.V1.Boundary
         public DateTime GeneratedAt { get; set; }
         public GetAllTenancyTransactionsRequest Request { get; set; }
         public List<TenancyTransaction> Transactions { get; set; }
-        public TenancyAgreementDetails TenancyDetails { get; set; }
     }
 }

--- a/transactions-api/V1/Boundary/GetTenancyDetailsRequest.cs
+++ b/transactions-api/V1/Boundary/GetTenancyDetailsRequest.cs
@@ -1,0 +1,10 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace transactions_api.V1.Boundary
+{
+    public class GetTenancyDetailsRequest
+    {
+        [FromRoute(Name = "payment_ref")] public string PaymentRef { get; set; }
+        [FromRoute(Name = "post_code")] public string PostCode { get; set; }
+    }
+}

--- a/transactions-api/V1/Boundary/GetTenancyDetailsResponse.cs
+++ b/transactions-api/V1/Boundary/GetTenancyDetailsResponse.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+using transactions_api.V1.Domain;
+
+namespace transactions_api.V1.Boundary
+{
+    public class GetTenancyDetailsResponse
+    {
+        public DateTime GeneratedAt { get; set; }
+        public GetTenancyDetailsRequest Request { get; set; }
+        public TenancyAgreementDetails TenancyDetails { get; set; }
+    }
+}

--- a/transactions-api/V1/Controllers/TransactionsController.cs
+++ b/transactions-api/V1/Controllers/TransactionsController.cs
@@ -81,6 +81,7 @@ namespace transactions_api.Controllers.V1
         [Route("tenancy-details/payment-ref/{payment_ref}/post-code/{post_code}")]                                              //should we add "GetAllTenancyTransactions/" to the start of the url?
         [Produces("application/json")]
         [ProducesResponseType(typeof(GetTenancyDetailsResponse), 200)]
+        [ProducesResponseType(typeof(ErrorResponse), 404)]
         public IActionResult GetTenancyDetails([FromRoute] GetTenancyDetailsRequest request)
         {
             _logger.LogInformation(                                                                             //TODO: Add tests for logging! An the rest of the logging. Add logging message formatter.
@@ -88,7 +89,15 @@ namespace transactions_api.Controllers.V1
                 );
 
                     var usecaseResponse = _listTransactions.ExecuteGetTenancyDetails(request);
+
+                    if (usecaseResponse.TenancyDetails != null)
                         return Ok(usecaseResponse);
+                    else
+                        return NotFound(
+                            new ErrorResponse(
+                                $"No tenancy details found for the payment reference = {request.PaymentRef} with the post code = {request.PostCode}"
+                                )
+                            );                                                                                      //I think the ErrorResponse should contain the Request object, but the standards go agains that right now. TODO: A thing to consider during refactoring.
         }
     }
 }

--- a/transactions-api/V1/Controllers/TransactionsController.cs
+++ b/transactions-api/V1/Controllers/TransactionsController.cs
@@ -8,7 +8,7 @@ using transactions_api.V1.Validation;
 namespace transactions_api.Controllers.V1
 {
     [ApiVersion("1")]
-    [Route("api/v1/transactions")]
+    [Route("api/v1")] // the tenancy details endpoint screw this up a bit for now..
     [ApiController]
     [Produces("application/json")]
     public class TransactionsController : BaseController
@@ -26,6 +26,7 @@ namespace transactions_api.Controllers.V1
 
         [ProducesResponseType(typeof(ListTransactionsResponse), 200)]
         [HttpGet]
+        [Route("transactions")]
         public JsonResult GetTransactions([FromQuery]ListTransactionsRequest request)
         {
             _logger.LogInformation("Transactions requested for TagRef: " + request.TagRef);
@@ -34,7 +35,7 @@ namespace transactions_api.Controllers.V1
         }
 
         [HttpGet]
-        [Route("payment-ref/{payment_ref}/post-code/{post_code}")]                                              //should we add "GetAllTenancyTransactions/" to the start of the url?
+        [Route("transactions/payment-ref/{payment_ref}/post-code/{post_code}")]                                              //should we add "GetAllTenancyTransactions/" to the start of the url?
         [Produces("application/json")]
         [ProducesResponseType(typeof(GetAllTenancyTransactionsResponse), 200)]
         [ProducesResponseType(typeof(ErrorResponse), 400)]
@@ -74,6 +75,16 @@ namespace transactions_api.Controllers.V1
                     new ErrorResponse(ex.Message)
                     );
             }
+        }
+
+        [HttpGet]
+        [Route("tenancy-details/payment-ref/{payment_ref}/post-code/{post_code}")]                                              //should we add "GetAllTenancyTransactions/" to the start of the url?
+        [Produces("application/json")]
+        [ProducesResponseType(typeof(GetTenancyDetailsResponse), 200)]
+        public IActionResult GetTenancyDetails([FromRoute] GetTenancyDetailsRequest request)
+        {
+                    var usecaseResponse = _listTransactions.ExecuteGetTenancyDetails(request);
+                        return Ok(usecaseResponse);
         }
     }
 }

--- a/transactions-api/V1/Controllers/TransactionsController.cs
+++ b/transactions-api/V1/Controllers/TransactionsController.cs
@@ -83,6 +83,10 @@ namespace transactions_api.Controllers.V1
         [ProducesResponseType(typeof(GetTenancyDetailsResponse), 200)]
         public IActionResult GetTenancyDetails([FromRoute] GetTenancyDetailsRequest request)
         {
+            _logger.LogInformation(                                                                             //TODO: Add tests for logging! An the rest of the logging. Add logging message formatter.
+                $"The request has hit GetTenancyDetails controller method with the following data. PaymentRef = {request.PaymentRef ?? "null" } and PostCode = {request.PostCode ?? "null"}"
+                );
+
                     var usecaseResponse = _listTransactions.ExecuteGetTenancyDetails(request);
                         return Ok(usecaseResponse);
         }

--- a/transactions-api/V1/Controllers/TransactionsController.cs
+++ b/transactions-api/V1/Controllers/TransactionsController.cs
@@ -16,12 +16,14 @@ namespace transactions_api.Controllers.V1
         private readonly IListTransactions _listTransactions;
         private readonly ILogger<TransactionsController> _logger;
         private readonly IGetTenancyTransactionsValidator _getTenancyTransactionsValidator;
+        private readonly IGetTenancyDetailsValidator _getTenancyDetailsValidator;
 
-        public TransactionsController(IListTransactions listTransactions, ILogger<TransactionsController> logger, IGetTenancyTransactionsValidator getTenancyTransactionsValidator)
+        public TransactionsController(IListTransactions listTransactions, ILogger<TransactionsController> logger, IGetTenancyTransactionsValidator getTenancyTransactionsValidator, IGetTenancyDetailsValidator getTenancyDetailsValidator)
         {
             _listTransactions = listTransactions;
             _logger = logger;
             _getTenancyTransactionsValidator = getTenancyTransactionsValidator;
+            _getTenancyDetailsValidator = getTenancyDetailsValidator;
         }
 
         [ProducesResponseType(typeof(ListTransactionsResponse), 200)]

--- a/transactions-api/V1/Controllers/TransactionsController.cs
+++ b/transactions-api/V1/Controllers/TransactionsController.cs
@@ -85,12 +85,15 @@ namespace transactions_api.Controllers.V1
         [ProducesResponseType(typeof(GetTenancyDetailsResponse), 200)]
         [ProducesResponseType(typeof(ErrorResponse), 400)]
         [ProducesResponseType(typeof(ErrorResponse), 404)]
+        [ProducesResponseType(typeof(ErrorResponse), 500)]
         public IActionResult GetTenancyDetails([FromRoute] GetTenancyDetailsRequest request)
         {
             _logger.LogInformation(                                                                             //TODO: Add tests for logging! An the rest of the logging. Add logging message formatter.
                 $"The request has hit GetTenancyDetails controller method with the following data. PaymentRef = {request.PaymentRef ?? "null" } and PostCode = {request.PostCode ?? "null"}"
                 );
 
+            try                                                                                                 //TODO: add tests for this. No tests due to this needing to be rushed!
+            {
                 var validationResult = _getTenancyDetailsValidator.Validate(request);
 
                 if (validationResult.IsValid)
@@ -110,6 +113,21 @@ namespace transactions_api.Controllers.V1
                 return BadRequest(
                     new ErrorResponse(validationResult.Errors)
                     );
+            }
+            catch (AggregateException ex) when (ex.InnerException != null)
+            {
+                return StatusCode(
+                    500,
+                    new ErrorResponse(ex.Message, ex.InnerException.Message)
+                    );
+            }
+            catch (Exception ex)
+            {
+                return StatusCode(
+                    500,
+                    new ErrorResponse(ex.Message)
+                    );
+            }
         }
     }
 }

--- a/transactions-api/V1/Controllers/TransactionsController.cs
+++ b/transactions-api/V1/Controllers/TransactionsController.cs
@@ -83,6 +83,7 @@ namespace transactions_api.Controllers.V1
         [Route("tenancy-details/payment-ref/{payment_ref}/post-code/{post_code}")]                                              //should we add "GetAllTenancyTransactions/" to the start of the url?
         [Produces("application/json")]
         [ProducesResponseType(typeof(GetTenancyDetailsResponse), 200)]
+        [ProducesResponseType(typeof(ErrorResponse), 400)]
         [ProducesResponseType(typeof(ErrorResponse), 404)]
         public IActionResult GetTenancyDetails([FromRoute] GetTenancyDetailsRequest request)
         {
@@ -90,6 +91,10 @@ namespace transactions_api.Controllers.V1
                 $"The request has hit GetTenancyDetails controller method with the following data. PaymentRef = {request.PaymentRef ?? "null" } and PostCode = {request.PostCode ?? "null"}"
                 );
 
+                var validationResult = _getTenancyDetailsValidator.Validate(request);
+
+                if (validationResult.IsValid)
+                {
                     var usecaseResponse = _listTransactions.ExecuteGetTenancyDetails(request);
 
                     if (usecaseResponse.TenancyDetails != null)
@@ -100,6 +105,11 @@ namespace transactions_api.Controllers.V1
                                 $"No tenancy details found for the payment reference = {request.PaymentRef} with the post code = {request.PostCode}"
                                 )
                             );                                                                                      //I think the ErrorResponse should contain the Request object, but the standards go agains that right now. TODO: A thing to consider during refactoring.
+                }
+
+                return BadRequest(
+                    new ErrorResponse(validationResult.Errors)
+                    );
         }
     }
 }

--- a/transactions-api/V1/Gateways/ITransactionsGateway.cs
+++ b/transactions-api/V1/Gateways/ITransactionsGateway.cs
@@ -6,7 +6,7 @@ namespace UnitTests.V1.Gateways
     public interface ITransactionsGateway
     {
         List<Transaction> GetTransactionsByTagRef(string propertyRef);
-        List<TenancyTransaction> GetAllTenancyTransactionStatements(string tenancyAgreementId, TenancyAgreementDetails tenantDet); // I know it could do away with tenanDet only, but I feel like making tenancyAgreementId an explicit requirement right now..
+        List<TenancyTransaction> GetAllTenancyTransactionStatements(string paymentReferenceNumber, string postcode);
         TenancyAgreementDetails GetTenancyAgreementDetails(string paymentReferenceNumber, string postcode);
         List<TempTenancyTransaction> GetAllTenancyTransactions(string tenancyAgreementRef);
     }

--- a/transactions-api/V1/Gateways/TransactionsGateway.cs
+++ b/transactions-api/V1/Gateways/TransactionsGateway.cs
@@ -148,50 +148,76 @@ namespace UnitTests.V1.Gateways
             uhtconn.Close();
 
             return result;
-
         }
 
-        public List<TenancyTransaction> GetAllTenancyTransactionStatements(string tenancyAgreementId, TenancyAgreementDetails tenantDet)
+        public List<TenancyTransaction> GetAllTenancyTransactionStatements(string paymentReferenceNumber, string postcode)
         {
-            List<TempTenancyTransaction> lstTransactions = GetAllTenancyTransactions(tenancyAgreementId);
-            List<TenancyTransaction> lstTransactionsState = new List<TenancyTransaction>();
-            float RecordBalance = 0;
-            RecordBalance = float.Parse(tenantDet.CurrentBalance);
+            SqlConnection uhtconn = new SqlConnection(_uhliveTransconnstring);
+            uhtconn.Open();
 
-            foreach (TempTenancyTransaction trans in lstTransactions)
+            postcode = Regex.Replace(postcode, @"\s+", String.Empty);
+
+            var tenantDet = uhtconn.QueryFirstOrDefault<TenancyAgreementDetails>(
+                @"
+					SELECT TNG.cur_bal                                   AS CurrentBalance,
+						   Rtrim(TNG.tag_ref)                            AS TenancyAgreementReference
+					FROM   tenagree TNG
+						   INNER JOIN property PRP
+								   ON TNG.prop_ref = PRP.prop_ref
+					WHERE  TNG.u_saff_rentacc = @paymentReferenceNumber
+						   AND REPLACE(PRP.post_code, ' ', '') = @postcode
+                ",
+                new { paymentReferenceNumber, postcode }
+            );
+
+            uhtconn.Close();
+
+            if (tenantDet != null && !String.IsNullOrEmpty(tenantDet.TenancyAgreementReference))
             {
-                TenancyTransaction statement = new TenancyTransaction();
-                var DebitValue = "";
-                var CreditValue = "";
-                float fDebitValue = 0F;
-                float fCreditValue = 0F;
-                var realvalue = trans.Amount;
-                string DisplayRecordBalance = (-RecordBalance).ToString("c2");
+                List<TempTenancyTransaction> lstTransactions = GetAllTenancyTransactions(tenantDet.TenancyAgreementReference);
 
-                if (realvalue.IndexOf("-") != -1)
+                List<TenancyTransaction> lstTransactionsState = new List<TenancyTransaction>();
+                float RecordBalance = 0;
+                RecordBalance = float.Parse(tenantDet.CurrentBalance);
+
+                foreach (TempTenancyTransaction trans in lstTransactions)
                 {
-                    DebitValue = realvalue;
-                    fDebitValue = float.Parse(DebitValue);
-                    RecordBalance = (RecordBalance - fDebitValue);
-                    DebitValue = (-fDebitValue).ToString("c2");
+                    TenancyTransaction statement = new TenancyTransaction();
+                    var DebitValue = "";
+                    var CreditValue = "";
+                    float fDebitValue = 0F;
+                    float fCreditValue = 0F;
+                    var realvalue = trans.Amount;
+                    string DisplayRecordBalance = (-RecordBalance).ToString("c2");
+
+                    if (realvalue.IndexOf("-") != -1)
+                    {
+                        DebitValue = realvalue;
+                        fDebitValue = float.Parse(DebitValue);
+                        RecordBalance = (RecordBalance - fDebitValue);
+                        DebitValue = (-fDebitValue).ToString("c2");
+                    }
+                    else
+                    {
+                        CreditValue = realvalue;
+                        fCreditValue = float.Parse(CreditValue);
+                        RecordBalance = (RecordBalance - fCreditValue);
+                        CreditValue = (-fCreditValue).ToString("c2");
+                    }
+                    statement.Date = trans.Date;
+                    statement.Description = trans.Description;
+                    statement.In = DebitValue;
+                    statement.Out = CreditValue;
+                    statement.Balance = DisplayRecordBalance;
+                    lstTransactionsState.Add(statement);
                 }
-                else
-                {
-                    CreditValue = realvalue;
-                    fCreditValue = float.Parse(CreditValue);
-                    RecordBalance = (RecordBalance - fCreditValue);
-                    CreditValue = (-fCreditValue).ToString("c2");
-                }
-                statement.Date = trans.Date;
-                statement.Description = trans.Description;
-                statement.In = DebitValue;
-                statement.Out = CreditValue;
-                statement.Balance = DisplayRecordBalance;
-                lstTransactionsState.Add(statement);
+
+                return lstTransactionsState; 
             }
-
-            return lstTransactionsState;
-
+            else
+            {
+                return new List<TenancyTransaction>();
+            }
         }
 
         //---------------------------------- Ported Code from NCC API (end) --------------------------------//

--- a/transactions-api/V1/UseCase/IListTransactions.cs
+++ b/transactions-api/V1/UseCase/IListTransactions.cs
@@ -4,5 +4,6 @@ namespace transactions_api.V1.Boundary
     {
         ListTransactionsResponse Execute(ListTransactionsRequest propertyRefrence);
         GetAllTenancyTransactionsResponse ExecuteGetTenancyTransactions(GetAllTenancyTransactionsRequest request);
+        GetTenancyDetailsResponse ExecuteGetTenancyDetails(GetTenancyDetailsRequest request);
     }
 }

--- a/transactions-api/V1/UseCase/ListTransactionsUsecase.cs
+++ b/transactions-api/V1/UseCase/ListTransactionsUsecase.cs
@@ -39,8 +39,7 @@ namespace transactions_api.UseCase
             {
                 GeneratedAt = DateTime.Now,
                 Request = request,
-                Transactions = transactions,
-                TenancyDetails = tenancyDetails                                                                         //This is no longer Transactions API... it's getting back Tenancy data!
+                Transactions = transactions
             };
         }
 

--- a/transactions-api/V1/UseCase/ListTransactionsUsecase.cs
+++ b/transactions-api/V1/UseCase/ListTransactionsUsecase.cs
@@ -43,5 +43,17 @@ namespace transactions_api.UseCase
                 TenancyDetails = tenancyDetails                                                                         //This is no longer Transactions API... it's getting back Tenancy data!
             };
         }
+
+        public GetTenancyDetailsResponse ExecuteGetTenancyDetails(GetTenancyDetailsRequest request)
+        {
+            var tenancyDetails = _transactionsGateway.GetTenancyAgreementDetails(request.PaymentRef, request.PostCode);
+
+            return new GetTenancyDetailsResponse()
+            {
+                GeneratedAt = DateTime.Now,
+                Request = request,
+                TenancyDetails = tenancyDetails
+            };
+        }
     }
 }

--- a/transactions-api/V1/UseCase/ListTransactionsUsecase.cs
+++ b/transactions-api/V1/UseCase/ListTransactionsUsecase.cs
@@ -29,11 +29,7 @@ namespace transactions_api.UseCase
 
         public GetAllTenancyTransactionsResponse ExecuteGetTenancyTransactions(GetAllTenancyTransactionsRequest request)
         {
-            var tenancyDetails = _transactionsGateway.GetTenancyAgreementDetails(request.PaymentRef, request.PostCode) ?? new TenancyAgreementDetails();
-
-            var transactions = !String.IsNullOrEmpty(tenancyDetails.TenancyAgreementReference)
-                               ? _transactionsGateway.GetAllTenancyTransactionStatements(tenancyDetails.TenancyAgreementReference, tenancyDetails)
-                               : new List<TenancyTransaction>();
+            var transactions = _transactionsGateway.GetAllTenancyTransactionStatements(request.PaymentRef, request.PostCode) ?? new List<TenancyTransaction>();
 
             return new GetAllTenancyTransactionsResponse()
             {

--- a/transactions-api/V1/Validation/GetTenancyDetailsValidator.cs
+++ b/transactions-api/V1/Validation/GetTenancyDetailsValidator.cs
@@ -1,0 +1,28 @@
+using FluentValidation;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using transactions_api.V1.Boundary;
+using transactions_api.V1.Helpers;
+
+namespace transactions_api.V1.Validation
+{
+    public class GetTenancyDetailsValidator : AbstractValidator<GetTenancyDetailsRequest>, IGetTenancyDetailsValidator
+    {
+        public GetTenancyDetailsValidator()
+        {
+            ValidatorOptions.Global.CascadeMode = CascadeMode.StopOnFirstFailure;
+            RuleFor(request => request.PaymentRef)
+                .NotNull().WithMessage(ErrorMessagesFormatter.FieldIsNullMessage("Payment reference"))
+                .NotEmpty().WithMessage(ErrorMessagesFormatter.FieldIsWhiteSpaceOrEmpty("Payment reference"));
+
+            RuleFor(request => request.PostCode)
+                .NotNull().WithMessage(ErrorMessagesFormatter.FieldIsNullMessage("Postcode"))
+                .NotEmpty().WithMessage(ErrorMessagesFormatter.FieldIsWhiteSpaceOrEmpty("Postcode"))
+                .Matches(new Regex("^((([A-Za-z][0-9]{1,2})|(([A-Za-z][A-Ha-hJ-Yj-y][0-9]{1,2})|(([A-Za-z][0-9][A-Za-z])|([A-Za-z][A-Ha-hJ-Yj-y][0-9][A-Za-z]))))( )?(([0-9][A-Za-z]?[A-Za-z]?)?))$")) //TODO: change the regex not to accept partial postcodes.
+                .WithMessage(ErrorMessagesFormatter.FieldWithIncorrectFormat("postcode"));
+        }
+    }
+}

--- a/transactions-api/V1/Validation/IGetTenancyDetailsValidator.cs
+++ b/transactions-api/V1/Validation/IGetTenancyDetailsValidator.cs
@@ -1,0 +1,14 @@
+using FluentValidation.Results;
+using transactions_api.V1.Boundary;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace transactions_api.V1.Validation
+{
+    public interface IGetTenancyDetailsValidator
+    {
+        ValidationResult Validate(GetTenancyDetailsRequest request);
+    }
+}


### PR DESCRIPTION
# What:
- A separation between getting Tenancy Details and Tenancy Transactions. They are no longer in the same endpoint, and no longer in the same response! Wohoo!
- A rushed second endpoint to host the getting of Tenancy Details.

# Why:
- After a second consideration it was decided that's it's better to separate Transactions from Tenancy Details out, as we had some time to do it while infrastructure issues were getting sorted out.
- Those two pieces of information shouldn't be going together in a microservice, even more so when it comes to a single response object.

# Notes:
- The second endpoint was not TDD'ed, so it does not have any Tests at all due to the time constraints. However it was at the very least smoke tested.
- The pipeline on this branch has probably failed because it's an outdated pipeline and it can't connect to AWS.
- The GetTenancyDetails endpoint should not belong on this API in the future. It's a temporary measure not to save time.
- Made the GetTenancyDetails and GetAllTenancyTransactions endpoints indepenedent of each other so that there would be less technical debt when it comes to getting TenancyDetails out of Transactions API.
- Not very happy with the Error Response. I think our API Playbook should be updated on this one for it to include the Request object along with the list of errors and the status. Reasoning for it - there's an inconsistency between the error response and the unwritten success responses standard that our past ~4-5 APIs are following. The idea was that you should see what you requested for when you get your data back. However I believe that you definitelly would want to see what you requested for if you get the error back.