### PR TITLE
Changes - modify validators

### DIFF
--- a/transactions-api.Tests/V1/Helper/TransactionHelper.cs
+++ b/transactions-api.Tests/V1/Helper/TransactionHelper.cs
@@ -92,6 +92,15 @@ namespace UnitTests.V1.Helper
             };
         }
 
+        public static GetTenancyDetailsRequest CreateGetTenancyDetailsRequestObject()
+        {
+            return new GetTenancyDetailsRequest()
+            {
+                PaymentRef = _faker.Random.Hash(),
+                PostCode = _faker.Address.ZipCode()
+            };
+        }
+
         #endregion
 
         #region Create Random Response Objects

--- a/transactions-api.Tests/V1/Validation/GetTenancyDetailsValidatorTests.cs
+++ b/transactions-api.Tests/V1/Validation/GetTenancyDetailsValidatorTests.cs
@@ -1,0 +1,144 @@
+using FluentValidation.TestHelper;
+using Moq;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using transactions_api.V1.Helpers;
+using transactions_api.V1.Validation;
+using transactions_api.V1.Validation.ValidatorBase;
+using UnitTests.V1.Helper;
+
+namespace transactions_api.Tests.V1.Validation
+{
+    [TestFixture]
+    public class GetTenancyDetailsValidatorTests
+    {
+        private GetTenancyDetailsValidator _validator;
+        private Mock<IPostCodeBaseValidator> _postcodeBaseValidator;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _postcodeBaseValidator = new Mock<IPostCodeBaseValidator>();
+            _validator = new GetTenancyDetailsValidator(_postcodeBaseValidator.Object);
+        }
+
+        #region Field Is Required [Null]
+
+        [Test]
+        public void given_a_request_with_null_PaymentRef_when_GetTenancyDetailsValidator_is_called_then_it_returns_an_error()
+        {
+            //arrange
+            var request = TransactionHelper.CreateGetTenancyDetailsRequestObject();
+            request.PaymentRef = null;
+
+            //act, assert
+            _validator.ShouldHaveValidationErrorFor(req => req.PaymentRef, request).WithErrorMessage(ErrorMessagesFormatter.FieldIsNullMessage("Payment reference"));
+        }
+
+        [Test]
+        public void given_a_request_with_null_PostCode_when_GetTenancyDetailsValidator_is_called_then_it_returns_an_error()
+        {
+            //arrange
+            var request = TransactionHelper.CreateGetTenancyDetailsRequestObject();
+            request.PostCode = null;
+
+            //act, assert
+            _validator.ShouldHaveValidationErrorFor(req => req.PostCode, request).WithErrorMessage(ErrorMessagesFormatter.FieldIsNullMessage("Postcode"));
+        }
+
+        #endregion
+
+
+        #region Field is required [Whitespace or Empty]
+
+        [TestCase("")]
+        [TestCase(" ")]
+        public void given_a_request_with_empty_or_whitespace_PaymentRef_when_GetTenancyDetailsValidator_is_called_then_it_returns_an_error(string paymentRef)
+        {
+            //arrange
+            var request = TransactionHelper.CreateGetTenancyDetailsRequestObject();
+            request.PaymentRef = paymentRef;
+
+            //act, assert
+            _validator.ShouldHaveValidationErrorFor(req => req.PaymentRef, request).WithErrorMessage(ErrorMessagesFormatter.FieldIsWhiteSpaceOrEmpty("Payment reference"));
+        }
+
+        [TestCase("")]
+        [TestCase(" ")]
+        public void given_a_request_with_empty_or_whitespace_PostCode_when_GetTenancyDetailsValidator_is_called_then_it_returns_an_error(string postCode)
+        {
+            //arrange
+            var request = TransactionHelper.CreateGetTenancyDetailsRequestObject();
+            request.PostCode = postCode;
+
+            //act, assert
+            _validator.ShouldHaveValidationErrorFor(req => req.PostCode, request).WithErrorMessage(ErrorMessagesFormatter.FieldIsWhiteSpaceOrEmpty("Postcode"));
+        }
+
+        #endregion
+
+        #region Postcode format validation
+
+        [Test]
+        public void given_a_nonempty_request_when_GetTenancyDetailsValidator_is_called_then_it_calls_PostCodeBaseValidator()       // non-empty because we want to stop on first failure.
+        {
+            var nonemptyRequest = TransactionHelper.CreateGetTenancyDetailsRequestObject();
+
+            _validator.Validate(nonemptyRequest);
+
+            _postcodeBaseValidator.Verify(bv => bv.ValidatePostCodeFormat(It.IsAny<string>()), Times.Once);
+        }
+
+        [Test]
+        public void given_a_nonempty_request_when_GetTenancyDetailsValidator_is_called_then_it_calls_PostCodeBaseValidator_with_the_PostCode_from_the_request()
+        {
+            var nonemptyRequest = TransactionHelper.CreateGetTenancyDetailsRequestObject();
+
+            _validator.Validate(nonemptyRequest);
+
+            _postcodeBaseValidator.Verify(bv => bv.ValidatePostCodeFormat(nonemptyRequest.PostCode), Times.Once);
+        }
+
+        [Test]
+        public void given_a_nonempty_request_with_valid_PostCode_format_when_GetTenancyDetailsValidator_is_called_then_it_returns_no_error()
+        {
+            //arange
+            var nonemptyRequest = TransactionHelper.CreateGetTenancyDetailsRequestObject();
+
+            _postcodeBaseValidator.Setup(bv => bv.ValidatePostCodeFormat(It.IsAny<string>())).Returns(true);                            // setup to trigger successful validation
+
+            //act, assert
+            _validator.ShouldNotHaveValidationErrorFor(req => req.PostCode, nonemptyRequest);
+        }
+
+        [Test]
+        public void given_a_nonempty_request_with_invalid_PostCode_format_when_GetTenancyDetailsValidator_is_called_then_it_returns_an_error_with_correct_message()
+        {
+            var nonemptyRequest = TransactionHelper.CreateGetTenancyDetailsRequestObject();
+
+            _postcodeBaseValidator.Setup(bv => bv.ValidatePostCodeFormat(It.IsAny<string>())).Returns(false);                           // setup to trigger failed validation
+
+            _validator.ShouldHaveValidationErrorFor(x => x.PostCode, nonemptyRequest).WithErrorMessage(ErrorMessagesFormatter.FieldWithIncorrectFormat("postcode"));
+        }
+
+        #endregion
+
+        #region Payment Ref validity tests
+
+        [Test]
+        public void given_a_request_with_valid_PaymentRef_when_GetTenancyDetailsValidator_is_called_then_it_returns_no_error()
+        {
+            //arange
+            var request = TransactionHelper.CreateGetTenancyDetailsRequestObject();
+
+            //act, assert
+            _validator.ShouldNotHaveValidationErrorFor(req => req.PaymentRef, request);
+        }
+
+        #endregion
+
+    }
+}

--- a/transactions-api.Tests/V1/Validation/GetTenancyTransactionsValidatorTests.cs
+++ b/transactions-api.Tests/V1/Validation/GetTenancyTransactionsValidatorTests.cs
@@ -87,7 +87,6 @@ namespace transactions_api.Tests.V1.Validation
         //"Unit" refers to the letters in the second part of the postcode (i.e. DN, JU) from (SW2 9DN, NE4 7JU)
 
         [TestCase("CR1 3ED")]
-        [TestCase("NE7")]
         public void GivenAPostCodeValueInUpperCase_WhenCallingValidation_ItReturnsNoErrors(string postCode)
         {
             var request = TransactionHelper.CreateGetAllTenancyTransactionsRequestObject();
@@ -96,7 +95,6 @@ namespace transactions_api.Tests.V1.Validation
         }
 
         [TestCase("w2 5jq")]
-        [TestCase("ne7")]
         public void GivenAPostCodeValueInLowerCase_WhenCallingValidation_ItReturnsNoErrors(string postCode)
         {
             var request = TransactionHelper.CreateGetAllTenancyTransactionsRequestObject();
@@ -107,15 +105,6 @@ namespace transactions_api.Tests.V1.Validation
         [TestCase("w2 5JQ")]
         [TestCase("E11 5ra")]
         public void GivenAPostCodeValueInLowerCaseAndUpperCase_WhenCallingValidation_ItReturnsNoErrors(string postCode)
-        {
-            var request = TransactionHelper.CreateGetAllTenancyTransactionsRequestObject();
-            request.PostCode = postCode;
-            _validator.ShouldNotHaveValidationErrorFor(x => x.PostCode, request);
-        }
-
-        [TestCase("w2 ")]
-        [TestCase("E11 ")]
-        public void GivenAnOutcodeWithSpace_WhenCallingValidation_ItReturnsNoErrors(string postCode)
         {
             var request = TransactionHelper.CreateGetAllTenancyTransactionsRequestObject();
             request.PostCode = postCode;
@@ -167,25 +156,6 @@ namespace transactions_api.Tests.V1.Validation
             _validator.ShouldHaveValidationErrorFor(x => x.PostCode, request).WithErrorMessage(ErrorMessagesFormatter.FieldWithIncorrectFormat("postcode"));
         }
 
-        [TestCase("E9")] //A9
-        [TestCase("S5")]
-        [TestCase("S11")] //A99
-        [TestCase("W12")]
-        [TestCase("NW9")] //AA9
-        [TestCase("RH5")]
-        [TestCase("SW17")] // AA99
-        [TestCase("NE17")]
-        [TestCase("W4R")] // A9A
-        [TestCase("N1C")]
-        [TestCase("NW1W")] // AA9A
-        [TestCase("CR1H")]
-        public void GivenOnlyAnOutcodePartOfPostCode_WhenCallingValidation_ItReturnsNoErrors(string postCode)
-        {
-            var request = TransactionHelper.CreateGetAllTenancyTransactionsRequestObject();
-            request.PostCode = postCode;
-            _validator.ShouldNotHaveValidationErrorFor(x => x.PostCode, request);
-        }
-
         [TestCase("E8 1LL")]
         [TestCase("SW17 1JK")]
         public void GivenBothPartsOfPostCode_WhenCallingValidation_ItReturnsNoErrors(string postCode)
@@ -211,24 +181,6 @@ namespace transactions_api.Tests.V1.Validation
             var request = TransactionHelper.CreateGetAllTenancyTransactionsRequestObject();
             request.PostCode = postCode;
             _validator.ShouldHaveValidationErrorFor(x => x.PostCode, request).WithErrorMessage(ErrorMessagesFormatter.FieldWithIncorrectFormat("postcode"));
-        }
-
-        [TestCase("SW11 9")]
-        [TestCase("e14 2")]
-        public void GivenAnOutcodeAndASector_WhenCallingValidation_ItReturnsNoErrors(string postCode)
-        {
-            var request = TransactionHelper.CreateGetAllTenancyTransactionsRequestObject();
-            request.PostCode = postCode;
-            _validator.ShouldNotHaveValidationErrorFor(x => x.PostCode, request);
-        }
-
-        [TestCase("SW7 9A")]
-        [TestCase("n12 8F")]
-        public void GivenAnOutcodeAndASectorAndTheFirstLetterOfTheUnit_WhenCallingValidation_ItReturnsNoErrors(string postCode)
-        {
-            var request = TransactionHelper.CreateGetAllTenancyTransactionsRequestObject();
-            request.PostCode = postCode;
-            _validator.ShouldNotHaveValidationErrorFor(x => x.PostCode, request);
         }
 
         [TestCase("N8 LL")]

--- a/transactions-api.Tests/V1/Validation/ValidatorBase/PostCodeBaseValidatorTests.cs
+++ b/transactions-api.Tests/V1/Validation/ValidatorBase/PostCodeBaseValidatorTests.cs
@@ -1,0 +1,194 @@
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using transactions_api.V1.Validation.ValidatorBase;
+
+namespace transactions_api.Tests.V1.Validation.ValidatorBase
+{
+    [TestFixture]
+    public class PostCodeBaseValidatorTests
+    {
+        private IPostCodeBaseValidator _postCodeBaseValidator;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _postCodeBaseValidator = new PostCodeBaseValidator();
+        }
+
+        #region Postcode format validation
+
+        // Below explanations all use the postcodes IG11 7QD and E5 3XW 
+        //"Incode" refers to the whole second part of the postcode (i.e. 3XW, 7QD) from (E11 3XW, W3 7QD)
+        //"Outcode" refers to the whole first part of the postcode (Letter(s) and number(s) - i.e. IG11, E5) from (IG11 9LL, E5 2LL)
+        //"Area" refers to the first letter(s) of the postcode (i.e.  IG, E) from (IG11 9LL, E5 2LL)
+        //"District" refers to first number(s) to appear in the postcode (i.e. 11, 5) from (IG11 9LL, E5 2LL)
+        //"Sector" refers to the number in the second part of the postcode (i.e. 9, 7) from (SW2 9DN, NE4 7JU)
+        //"Unit" refers to the letters in the second part of the postcode (i.e. DN, JU) from (SW2 9DN, NE4 7JU)
+
+        [TestCase("CR1 3ED")]
+        public void GivenAPostCodeValueInUpperCase_WhenCallingValidation_ItReturnsNoErrors(string postCode)
+        {
+            var validationResult = _postCodeBaseValidator.ValidatePostCodeFormat(postCode);
+
+            Assert.True(validationResult);
+        }
+
+        [TestCase("w2 5jq")]
+        public void GivenAPostCodeValueInLowerCase_WhenCallingValidation_ItReturnsNoErrors(string postCode)
+        {
+            var validationResult = _postCodeBaseValidator.ValidatePostCodeFormat(postCode);
+
+            Assert.True(validationResult);
+        }
+
+        [TestCase("w2 5JQ")]
+        [TestCase("E11 5ra")]
+        public void GivenAPostCodeValueInLowerCaseAndUpperCase_WhenCallingValidation_ItReturnsNoErrors(string postCode)
+        {
+            var validationResult = _postCodeBaseValidator.ValidatePostCodeFormat(postCode);
+
+            Assert.True(validationResult);
+        }
+
+        [TestCase("CR13ED")]
+        [TestCase("RE15AD")]
+        public void GivenPostCodeValueWithoutSpaces_WhenCallingValidation_ItReturnsNoErrors(string postCode)
+        {
+            var validationResult = _postCodeBaseValidator.ValidatePostCodeFormat(postCode);
+
+            Assert.True(validationResult);
+        }
+
+        [TestCase("NW")]
+        [TestCase("E")]
+        public void GivenOnlyAnAreaPartOfThePostCode_WhenCallingValidation_ItReturnsAnError(string postCode)
+        {
+            var validationResult = _postCodeBaseValidator.ValidatePostCodeFormat(postCode);
+
+            Assert.False(validationResult);
+        }
+
+        [TestCase("17 9LL")]
+        [TestCase("8 1LA")]
+        public void GivenOnlyAnIncodeAndADistrictPartsOfThePostCode_WhenCallingValidation_ItReturnsAnError(string postCode)
+        {
+            var validationResult = _postCodeBaseValidator.ValidatePostCodeFormat(postCode);
+
+            Assert.False(validationResult);
+        }
+
+        [TestCase("NW 9LL")]
+        [TestCase("NR1LW")]
+        public void GivenOnlyAnIncodeAndAnAreaPartsOfThePostCode_WhenCallingValidation_ItReturnsAnError(string postCode)
+        {
+            var validationResult = _postCodeBaseValidator.ValidatePostCodeFormat(postCode);
+
+            Assert.False(validationResult);
+        }
+
+        [TestCase("1LL")]
+        [TestCase(" 6BQ")]
+        public void GivenOnlyAnIncodePartOfThePostCode_WhenCallingValidation_ItReturnsAnError(string postCode)
+        {
+            var validationResult = _postCodeBaseValidator.ValidatePostCodeFormat(postCode);
+
+            Assert.False(validationResult);
+        }
+
+        [TestCase("E8 1LL")]
+        [TestCase("SW17 1JK")]
+        public void GivenBothPartsOfPostCode_WhenCallingValidation_ItReturnsNoErrors(string postCode)
+        {
+            var validationResult = _postCodeBaseValidator.ValidatePostCodeFormat(postCode);
+
+            Assert.True(validationResult);
+        }
+
+        [TestCase("IG117QDfdsfdsfd")]
+        [TestCase("E1llolol")]
+        public void GivenAValidPostcodeFolowedByRandomCharacters_WhenCallingValidation_ItReturnsAnError(string postCode)
+        {
+            var validationResult = _postCodeBaseValidator.ValidatePostCodeFormat(postCode);
+
+            Assert.False(validationResult);
+        }
+
+        [TestCase("EEE")]
+        [TestCase("THE")]
+        public void GivenThreeCharacters_WhenCallingValidation_ItReturnsAnError(string postCode)
+        {
+            var validationResult = _postCodeBaseValidator.ValidatePostCodeFormat(postCode);
+
+            Assert.False(validationResult);
+        }
+
+        [TestCase("N8 LL")]
+        [TestCase("NW11 AE")]
+        public void GivenAnOutcodeAndAUnit_WhenCallingValidation_ItReturnsAnError(string postCode)
+        {
+            var validationResult = _postCodeBaseValidator.ValidatePostCodeFormat(postCode);
+
+            Assert.False(validationResult);
+        }
+
+        [TestCase("S10 H")]
+        [TestCase("W1 J")]
+        public void GivenAnOutcodeAndOnlyOneLetterOfAUnit_WhenCallingValidation_ItReturnsAnError(string postCode)
+        {
+            var validationResult = _postCodeBaseValidator.ValidatePostCodeFormat(postCode);
+
+            Assert.False(validationResult);
+        }
+
+        [TestCase("w2 ")]
+        [TestCase("E11 ")]
+        public void GivenAnOutcodeWithSpace_WhenCallingValidation_ItReturnsAnError(string postCode)
+        {
+            var validationResult = _postCodeBaseValidator.ValidatePostCodeFormat(postCode);
+
+            Assert.False(validationResult);
+        }
+
+        [TestCase("E9")] //A9
+        [TestCase("S5")]
+        [TestCase("S11")] //A99
+        [TestCase("W12")]
+        [TestCase("NW9")] //AA9
+        [TestCase("RH5")]
+        [TestCase("SW17")] // AA99
+        [TestCase("NE17")]
+        [TestCase("W4R")] // A9A
+        [TestCase("N1C")]
+        [TestCase("NW1W")] // AA9A
+        [TestCase("CR1H")]
+        public void GivenOnlyAnOutcodePartOfPostCode_WhenCallingValidation_ItReturnsAnError(string postCode)
+        {
+            var validationResult = _postCodeBaseValidator.ValidatePostCodeFormat(postCode);
+
+            Assert.False(validationResult);
+        }
+
+        [TestCase("SW11 9")]
+        [TestCase("e14 2")]
+        public void GivenAnOutcodeAndASector_WhenCallingValidation_ItReturnsAnError(string postCode)
+        {
+            var validationResult = _postCodeBaseValidator.ValidatePostCodeFormat(postCode);
+
+            Assert.False(validationResult);
+        }
+
+        [TestCase("SW7 9A")]
+        [TestCase("n12 8F")]
+        public void GivenAnOutcodeAndASectorAndTheFirstLetterOfTheUnit_WhenCallingValidation_ItReturnsAnError(string postCode)
+        {
+            var validationResult = _postCodeBaseValidator.ValidatePostCodeFormat(postCode);
+
+            Assert.False(validationResult);
+        }
+
+        #endregion
+    }
+}

--- a/transactions-api/Startup.cs
+++ b/transactions-api/Startup.cs
@@ -20,6 +20,7 @@ using transactions_api.Versioning;
 using UnitTests.V1.Infrastructure;
 using FluentValidation.AspNetCore;
 using transactions_api.V1.Validation;
+using transactions_api.V1.Validation.ValidatorBase;
 
 namespace transactions_api
 {
@@ -96,6 +97,7 @@ namespace transactions_api
             ConfigureDbContext(services);
             RegisterGateWays(services);
             RegisterUseCases(services);
+            RegisterValidatorBases(services);
             RegisterValidators(services);
             services.AddMvcCore().AddDataAnnotations();
         }
@@ -118,6 +120,11 @@ namespace transactions_api
         private static void RegisterUseCases(IServiceCollection services)
         {
             services.AddSingleton<IListTransactions, ListTransactionsUsecase>();
+        }
+
+        private static void RegisterValidatorBases(IServiceCollection services)
+        {
+            services.AddTransient<IPostCodeBaseValidator, PostCodeBaseValidator>();
         }
 
         private static void RegisterValidators(IServiceCollection services)

--- a/transactions-api/V1/Validation/GetTenancyDetailsValidator.cs
+++ b/transactions-api/V1/Validation/GetTenancyDetailsValidator.cs
@@ -21,7 +21,7 @@ namespace transactions_api.V1.Validation
             RuleFor(request => request.PostCode)
                 .NotNull().WithMessage(ErrorMessagesFormatter.FieldIsNullMessage("Postcode"))
                 .NotEmpty().WithMessage(ErrorMessagesFormatter.FieldIsWhiteSpaceOrEmpty("Postcode"))
-                .Matches(new Regex("^((([A-Za-z][0-9]{1,2})|(([A-Za-z][A-Ha-hJ-Yj-y][0-9]{1,2})|(([A-Za-z][0-9][A-Za-z])|([A-Za-z][A-Ha-hJ-Yj-y][0-9][A-Za-z]))))( )?(([0-9][A-Za-z]?[A-Za-z]?)?))$")) //TODO: change the regex not to accept partial postcodes.
+                .Matches(new Regex("^[A-Za-z]{1,2}[0-9][A-Za-z0-9]? ?[0-9][A-Za-z]{2}$"))
                 .WithMessage(ErrorMessagesFormatter.FieldWithIncorrectFormat("postcode"));
         }
     }

--- a/transactions-api/V1/Validation/GetTenancyDetailsValidator.cs
+++ b/transactions-api/V1/Validation/GetTenancyDetailsValidator.cs
@@ -6,13 +6,22 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using transactions_api.V1.Boundary;
 using transactions_api.V1.Helpers;
+using transactions_api.V1.Validation.ValidatorBase;
 
 namespace transactions_api.V1.Validation
 {
     public class GetTenancyDetailsValidator : AbstractValidator<GetTenancyDetailsRequest>, IGetTenancyDetailsValidator
     {
-        public GetTenancyDetailsValidator()
+        private readonly IPostCodeBaseValidator _postcodeBaseValidator;
+
+        public GetTenancyDetailsValidator(IPostCodeBaseValidator postcodeBaseValidator)
         {
+            #region Injecting dependencies
+
+            _postcodeBaseValidator = postcodeBaseValidator;
+
+            #endregion
+
             ValidatorOptions.Global.CascadeMode = CascadeMode.StopOnFirstFailure;
             RuleFor(request => request.PaymentRef)
                 .NotNull().WithMessage(ErrorMessagesFormatter.FieldIsNullMessage("Payment reference"))
@@ -21,7 +30,7 @@ namespace transactions_api.V1.Validation
             RuleFor(request => request.PostCode)
                 .NotNull().WithMessage(ErrorMessagesFormatter.FieldIsNullMessage("Postcode"))
                 .NotEmpty().WithMessage(ErrorMessagesFormatter.FieldIsWhiteSpaceOrEmpty("Postcode"))
-                .Matches(new Regex("^[A-Za-z]{1,2}[0-9][A-Za-z0-9]? ?[0-9][A-Za-z]{2}$"))
+                .Must(_postcodeBaseValidator.ValidatePostCodeFormat)
                 .WithMessage(ErrorMessagesFormatter.FieldWithIncorrectFormat("postcode"));
         }
     }

--- a/transactions-api/V1/Validation/GetTenancyTransactionsValidator.cs
+++ b/transactions-api/V1/Validation/GetTenancyTransactionsValidator.cs
@@ -21,7 +21,7 @@ namespace transactions_api.V1.Validation
             RuleFor(request => request.PostCode)
                 .NotNull().WithMessage(ErrorMessagesFormatter.FieldIsNullMessage("Postcode"))
                 .NotEmpty().WithMessage(ErrorMessagesFormatter.FieldIsWhiteSpaceOrEmpty("Postcode"))
-                .Matches(new Regex("^((([A-Za-z][0-9]{1,2})|(([A-Za-z][A-Ha-hJ-Yj-y][0-9]{1,2})|(([A-Za-z][0-9][A-Za-z])|([A-Za-z][A-Ha-hJ-Yj-y][0-9][A-Za-z]))))( )?(([0-9][A-Za-z]?[A-Za-z]?)?))$"))
+                .Matches(new Regex("^[A-Za-z]{1,2}[0-9][A-Za-z0-9]? ?[0-9][A-Za-z]{2}$"))
                 .WithMessage(ErrorMessagesFormatter.FieldWithIncorrectFormat("postcode"));
         }
     }

--- a/transactions-api/V1/Validation/GetTenancyTransactionsValidator.cs
+++ b/transactions-api/V1/Validation/GetTenancyTransactionsValidator.cs
@@ -6,13 +6,22 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using transactions_api.V1.Boundary;
 using transactions_api.V1.Helpers;
+using transactions_api.V1.Validation.ValidatorBase;
 
 namespace transactions_api.V1.Validation
 {
     public class GetTenancyTransactionsValidator : AbstractValidator<GetAllTenancyTransactionsRequest>, IGetTenancyTransactionsValidator
     {
-        public GetTenancyTransactionsValidator()
+        private readonly IPostCodeBaseValidator _postcodeBaseValidator;
+
+        public GetTenancyTransactionsValidator(IPostCodeBaseValidator postcodeBaseValidator)
         {
+            #region Injecting dependencies
+
+            _postcodeBaseValidator = postcodeBaseValidator;
+
+            #endregion
+
             ValidatorOptions.Global.CascadeMode = CascadeMode.StopOnFirstFailure;
             RuleFor(request => request.PaymentRef)
                 .NotNull().WithMessage(ErrorMessagesFormatter.FieldIsNullMessage("Payment reference"))
@@ -21,7 +30,7 @@ namespace transactions_api.V1.Validation
             RuleFor(request => request.PostCode)
                 .NotNull().WithMessage(ErrorMessagesFormatter.FieldIsNullMessage("Postcode"))
                 .NotEmpty().WithMessage(ErrorMessagesFormatter.FieldIsWhiteSpaceOrEmpty("Postcode"))
-                .Matches(new Regex("^[A-Za-z]{1,2}[0-9][A-Za-z0-9]? ?[0-9][A-Za-z]{2}$"))
+                .Must(_postcodeBaseValidator.ValidatePostCodeFormat)
                 .WithMessage(ErrorMessagesFormatter.FieldWithIncorrectFormat("postcode"));
         }
     }

--- a/transactions-api/V1/Validation/ValidatorBase/IPostCodeBaseValidator.cs
+++ b/transactions-api/V1/Validation/ValidatorBase/IPostCodeBaseValidator.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace transactions_api.V1.Validation.ValidatorBase
+{
+    /// <summary>
+    /// The implementation should contain methods related to postcode validation.
+    /// In this case it would be postcode format validation (and postcode characters validation - if needed later on).
+    /// </summary>
+    public interface IPostCodeBaseValidator
+    {
+        bool ValidatePostCodeFormat(string postcode);
+    }
+}

--- a/transactions-api/V1/Validation/ValidatorBase/PostCodeBaseValidator.cs
+++ b/transactions-api/V1/Validation/ValidatorBase/PostCodeBaseValidator.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace transactions_api.V1.Validation.ValidatorBase
+{
+    public class PostCodeBaseValidator : IPostCodeBaseValidator
+    {
+        public bool ValidatePostCodeFormat(string postcode)
+        {
+            var postcodeFormatPattern = new Regex("^[A-Za-z]{1,2}[0-9][A-Za-z0-9]? ?[0-9][A-Za-z]{2}$");
+
+            var isFormatValid = postcodeFormatPattern.IsMatch(postcode);
+
+            return isFormatValid;
+        }
+    }
+}


### PR DESCRIPTION
# What:
- Stricter postcode validation, which requires to enter full postcode rathter than partial one.
- Improved validator architecture.
- Added missing tests for GetTenancyDetailsValidator.


# Why:
- The initial **postcode validation** used was taken from [Hackney Addresses API](https://github.com/LBHackney-IT/HackneyAddressesAPI), where the postcode was being used for the sake of search, hence there was a requirement for partial postcode to be accepted. On transactions API however, the postcode is used for a security check, hence full postcode is needed.

- The way we do **_validators_** had to be changed due to **increasing amounts of repeated tests**. Any **Custom validation** _(like regex, or guid parsing, etc.)_ **requires testing of all the edge cases**.
﻿
The issue appears, when within a single API there might be multiple endpoints that are going to be validating that same type of data. Due to our validators being defined in terms of request objects, it means that there will be a validator per endpoint!
﻿
If multiple endpoints are taking the same inputs that require custom validation, it means that there needs to be a **set of tests** for that exact same validation **per validator** _(per endpoint)_ - leading to those same **tests being repeated** multiple times, violating the **DRY** principle.
﻿
An example of that can be seen pretty well on [Mat-Process-API](https://github.com/LBHackney-IT/mat-process-api), where the tests for GUID validation were being pointlessly repeated multiple times:
﻿
﻿- [Post Image](https://github.com/LBHackney-IT/mat-process-api/blob/master/mat-process-api.Tests/V1/Validators/PostProcessImageRequestValidatorTests.cs#L66-L92)
﻿- [Post Initial Document](https://github.com/LBHackney-IT/mat-process-api/blob/master/mat-process-api.Tests/V1/Validators/PostInitialProcessDocumentRequestValidatorTests.cs#L83-L91)
﻿- [Get Process](https://github.com/LBHackney-IT/mat-process-api/blob/master/mat-process-api.Tests/V1/Validators/GetProcessRequestValidatorTest.cs#L39-L47)
﻿- [Get Process Image](https://github.com/LBHackney-IT/mat-process-api/blob/master/mat-process-api.Tests/V1/Validators/GetProcessImageRequestValidatorTests.cs#L125-L151).
﻿
This might not seem too bad, but imagine if there were multiple endpoints requiring [partial postcode validation](https://github.com/LBHackney-IT/HackneyAddressesAPI/blob/master/LBHAddressesAPITest/Validation/SearchAddressValidatorTests.cs#L57-L211), needing these tests _(from the link)_ to be repeated about 4 times. In the case with transactions API, the postcode validation would have had to be repeated twice at this current time.

- Added tests to cover GetTenancyDetailsValidator as it was untested due to it being written in a rush.


# Notes:
- The new way of writting validators also has a benefit of **seperating the concerns** of the **Main validator** _(where we check **if** it performs the validations, and gives correct error messages)_, and the **Base validators** _(where we test **how** particular validation works by checking all the edge cases)_. In short, edge case tests go into a different file and don't need to repeated again.
- The core idea is building up the Main validator by injecting Base validator dependencies. That way the validator for the endpoint can be built up like LEGO.