### PR TITLE
Changed type of the two dates to be DateTime because Dapper was doing…

### DIFF
--- a/transactions-api.Tests/V1/Helper/TransactionHelper.cs
+++ b/transactions-api.Tests/V1/Helper/TransactionHelper.cs
@@ -34,7 +34,7 @@ namespace UnitTests.V1.Helper
         {
             return new TempTenancyTransaction()
             {
-                Date = _faker.Date.Past().ToString("dd/MM/yyyy HH:mm:ss"),
+                Date = _faker.Date.Past(),
                 Amount = _faker.Finance.Amount(-500, 500, 2).ToString(),
                 Type = _faker.Random.Word(),
                 Description = _faker.Random.Words(3)

--- a/transactions-api/V1/Domain/TenancyTransaction.cs
+++ b/transactions-api/V1/Domain/TenancyTransaction.cs
@@ -7,7 +7,7 @@ namespace transactions_api.V1.Domain                            //This is where 
 {
     public class TenancyTransaction                             //'In' and 'Out' - don't think it makes sense to have it like this long term. I think it's Front-End's responsibility to distinguish between positive and negative amounts.
     {
-        public string Date { get; set; }
+        public DateTime Date { get; set; }
         public string Description { get; set; }
         public string In { get; set; }
         public string Out { get; set; }
@@ -16,7 +16,7 @@ namespace transactions_api.V1.Domain                            //This is where 
 
     public class TempTenancyTransaction                         //Temporary class from NCC so that the data from sql query would get automapped. But I think this should be our return object with an addition of balance.
     {
-        public string Date { get; set; }
+        public DateTime Date { get; set; }
         public string Amount { get; set; }
         public string Type { get; set; }
         public string Description { get; set; }


### PR DESCRIPTION
… odd things with the dates...

Don't have dates as Strings!!!!!!!!
Response was flipping dates to be US format because the property was a String instead of DateTime. So 6th June looked like 6th November.
"date": "06/11/2020 00:00:00"

Now it'll look like this "date": "2020-06-11T00:00:00"
 
